### PR TITLE
[feat] 카카오 소셜 로그인 1차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,11 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'org.json:json:20231013'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     runtimeOnly 'com.h2database:h2'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/zipup/server/global/config/CorsConfig.java
+++ b/src/main/java/com/zipup/server/global/config/CorsConfig.java
@@ -1,0 +1,32 @@
+package com.zipup.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+public class CorsConfig {
+  @Value("${server.address}")
+  private String server;
+  @Value("${client.address}")
+  private String client;
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.addAllowedOrigin(server);
+    configuration.addAllowedOrigin(client);
+
+    configuration.setAllowCredentials(true);
+    configuration.setAllowedMethods(Collections.singletonList("*"));
+
+    final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
+}

--- a/src/main/java/com/zipup/server/global/exception/BaseException.java
+++ b/src/main/java/com/zipup/server/global/exception/BaseException.java
@@ -1,0 +1,12 @@
+package com.zipup.server.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BaseException extends RuntimeException {
+    private CustomErrorCode status;
+}

--- a/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
@@ -1,0 +1,46 @@
+package com.zipup.server.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+  /**
+   * 2000 : Request 오류
+   */
+  // Common
+  REQUEST_ERROR(2000, "입력값을 확인해주세요."),
+  EMPTY_ACCESS_JWT( 2001, "Access 토큰을 입력해주세요."),
+  EMPTY_REFRESH_JWT( 2002, "Refresh 토큰을 입력해주세요."),
+  WRONG_TYPE_TOKEN( 2003, "잘못된 토큰 입니다."),
+  UNSUPPORTED_TOKEN( 2004, "지원되지 않는 토큰 입니다."),
+  NOT_EXIST_TOKEN(2005,"존재하지 않거나 만료된 토큰입니다. 다시 로그인해주세요."),
+  EXPIRED_TOKEN(2006,"만료된 Access 토큰입니다. Refresh 토큰을 이용해서 새로운 Access 토큰을 발급 받으세요."),
+  TOKEN_NOT_FOUND( 2007, "토큰이 존재하지 않습니다."),
+  ACCESS_DENIED(2008, "권한이 없습니다."),
+
+  // users
+  INVALID_USER_UUID(2101, "유저 정보를 불러오는데 실패했습니다"),
+
+  /**
+   * 3000 : Response 오류
+   */
+  // Common
+  RESPONSE_ERROR(3000, "값을 불러오는데 실패하였습니다."),
+
+  /**
+   * 4000 : 연결 오류
+   */
+  DATABASE_ERROR(4000, "데이터베이스 연결에 실패하였습니다."),
+  SERVER_ERROR(4001, "서버와의 연결에 실패하였습니다."),
+  REDIS_ERROR(4002, "redis 연결에 실패하였습니다."),
+
+  /**
+   * 5000 : 알 수 없는 오류
+   */
+  UNKNOWN_ERROR(5002, "알 수 없는 에러가 발생했습니다.");
+
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/zipup/server/global/exception/ErrorResponse.java
+++ b/src/main/java/com/zipup/server/global/exception/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.zipup.server.global.exception;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@EqualsAndHashCode
+public class ErrorResponse {
+  private final int code;
+  private final String message;
+  private final List<String> errors;
+
+  public ErrorResponse(int code, String message, String error) {
+    this.code = code;
+    this.message = message;
+    this.errors = List.of(error);
+  }
+
+  public static ErrorResponse toErrorResponse(CustomErrorCode errorCode) {
+    return new ErrorResponse(
+            errorCode.getCode(),
+            errorCode.name(),
+            errorCode.getMessage());
+  }
+}

--- a/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,79 @@
+package com.zipup.server.global.exception;
+
+import javax.persistence.NoResultException;
+import javax.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(NoResultException.class)
+  public ResponseEntity<?> handleNoResultException(NoResultException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<?> handleIllegalStateException(IllegalStateException ex) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  @ResponseBody
+  public ResponseEntity<String> handleMissingServletRequestParameter(MissingServletRequestParameterException ex) {
+    return new ResponseEntity<>("필수 parameter '" + ex.getParameterName() + "' 가 빠졌습니다.", HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<?> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+    return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<String> handleConstraintViolationException(ConstraintViolationException ex) {
+    StringBuilder errorMessage = new StringBuilder();
+    ex.getConstraintViolations().forEach(violation -> {
+      errorMessage.append(violation.getMessage()).append("\n");
+    });
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage.toString());
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(NoSuchElementException.class)
+  protected ResponseEntity<String> handleNoSuchElementException(NoSuchElementException ex) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ex.getMessage());
+  }
+
+  @ExceptionHandler(BaseException.class)
+  protected ResponseEntity<ErrorResponse> handleBaseException(BaseException ex) {
+    log.error("--- CustomException ---", ex);
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse.toErrorResponse(ex.getStatus()));
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/config/JwtSecurityConfig.java
+++ b/src/main/java/com/zipup/server/global/security/config/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.zipup.server.global.security.config;
+
+import com.zipup.server.global.security.filter.JwtAuthenticationFilter;
+import com.zipup.server.global.security.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+  private final JwtProvider jwtProvider;
+
+  @Override
+  public void configure(HttpSecurity http) throws Exception {
+    JwtAuthenticationFilter customFilter = new JwtAuthenticationFilter(jwtProvider);
+    http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+  }
+}

--- a/src/main/java/com/zipup/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/zipup/server/global/security/config/SecurityConfig.java
@@ -1,0 +1,157 @@
+package com.zipup.server.global.security.config;
+
+import com.zipup.server.global.config.CorsConfig;
+import com.zipup.server.global.security.filter.CustomAuthenticationEntryPoint;
+import com.zipup.server.global.security.handler.CustomAccessDeniedHandler;
+import com.zipup.server.global.security.handler.CustomAuthenticationFailureHandler;
+import com.zipup.server.global.security.handler.CustomAuthenticationSuccessHandler;
+import com.zipup.server.global.security.oauth.CustomOAuth2UserService;
+import com.zipup.server.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.zipup.server.global.security.util.JwtProvider;
+import com.zipup.server.user.application.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.util.StringUtils;
+
+import java.util.Set;
+
+import static com.zipup.server.global.exception.CustomErrorCode.NOT_EXIST_TOKEN;
+import static com.zipup.server.global.exception.CustomErrorCode.TOKEN_NOT_FOUND;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityConfig {
+  private final CorsConfig corsConfig;
+  private final JwtProvider jwtProvider;
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final UserService userService;
+  private final RedisTemplate<String, String> redisTemplate;
+  private static final String[] AUTH_WHITELIST = {
+          "/error",
+          "/*/oauth2/code/*",
+          "/favicon.ico",
+          "/swagger-resources/**",
+          "/configuration/ui",
+          "/configuration/security",
+          "/swagger-ui/**",
+          "/webjars/**",
+          "/h2-console/**",
+          "/api/v1/user/sign-**",
+          "/api/v1/auth/**",
+          "/v3/api-docs/**"
+  };
+
+  @Bean
+  public HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository() {
+    return new HttpCookieOAuth2AuthorizationRequestRepository();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+            .csrf(CsrfConfigurer::disable)
+            .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
+            .sessionManagement(sessionManagement ->
+                    sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .formLogin(FormLoginConfigurer::disable)
+            .httpBasic(HttpBasicConfigurer::disable)
+            .headers(headerConfig ->
+                    headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+
+            .authorizeRequests(authorizeRequests ->
+                    authorizeRequests
+                            .antMatchers(HttpMethod.GET).permitAll()
+                            .antMatchers(AUTH_WHITELIST).permitAll()
+                            .anyRequest().authenticated())
+
+            .oauth2Login(oauth ->
+                    oauth.authorizationEndpoint(endpoint ->
+                            endpoint.authorizationRequestRepository(authorizationRequestRepository()))
+                          .userInfoEndpoint(user -> user.userService(customOAuth2UserService))
+                          .successHandler(oAuth2AuthenticationSuccessHandler())
+                          .failureHandler(oAuth2AuthenticationFailureHandler()))
+
+            .logout(logoutConfigurer -> logoutConfigurer
+                    .logoutUrl("/api/v1/auth/sign-out")
+                    .addLogoutHandler(logoutHandler())
+                    .logoutSuccessUrl("/")
+                    .deleteCookies(HttpHeaders.AUTHORIZATION))
+
+            .exceptionHandling(exceptionHandlingConfigurer ->
+                    exceptionHandlingConfigurer
+                            .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                            .accessDeniedHandler(new CustomAccessDeniedHandler()));
+
+    http.apply(new JwtSecurityConfig(jwtProvider));
+
+    return http.build();
+  }
+
+  @Bean
+  public LogoutHandler logoutHandler() {
+    return (request, response, authentication) -> {
+      try {
+          String token = jwtProvider.resolveToken(request);
+          if (!StringUtils.hasText(token))
+            request.setAttribute("exception", TOKEN_NOT_FOUND);
+
+          if (jwtProvider.validateToken(token))
+            request.setAttribute("exception", NOT_EXIST_TOKEN);
+          Authentication auth = jwtProvider.getAuthenticationByToken(token);
+
+          Set<String> keysToDelete = redisTemplate.keys(auth.getName() + "*");
+
+          if (keysToDelete != null)
+            redisTemplate.delete(keysToDelete);
+      } catch (Exception e) {
+        request.setAttribute("exception", NOT_EXIST_TOKEN);
+        log.error(e.getMessage());
+        log.error(e.getClass().getName());
+      }
+    };
+  }
+
+  /*
+   * 암호화에 필요한 PasswordEncoder Bean 등록
+   * */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  /*
+   * Oauth 인증 성공 핸들러
+   * */
+  @Bean
+  public CustomAuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
+    return new CustomAuthenticationSuccessHandler(userService, authorizationRequestRepository());
+  }
+
+  /*
+   * Oauth 인증 실패 핸들러
+   * */
+  @Bean
+  public CustomAuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
+    return new CustomAuthenticationFailureHandler(authorizationRequestRepository());
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/domain/Token.java
+++ b/src/main/java/com/zipup/server/global/security/domain/Token.java
@@ -1,0 +1,30 @@
+package com.zipup.server.global.security.domain;
+
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.util.concurrent.TimeUnit;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@RedisHash("token")
+public class Token {
+  @Id
+  private String id;
+
+  @Indexed
+  private String accessToken;
+
+  private String refreshToken;
+
+  @TimeToLive(unit = TimeUnit.MILLISECONDS)
+  private Long timeToLive;
+}

--- a/src/main/java/com/zipup/server/global/security/domain/TokenRepository.java
+++ b/src/main/java/com/zipup/server/global/security/domain/TokenRepository.java
@@ -1,0 +1,10 @@
+package com.zipup.server.global.security.domain;
+
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends KeyValueRepository<Token, String> {
+  Optional<Token> findByAccessToken(String accessToken);
+  Optional<Token> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/zipup/server/global/security/exception/OAuthProviderMissMatchException.java
+++ b/src/main/java/com/zipup/server/global/security/exception/OAuthProviderMissMatchException.java
@@ -1,0 +1,11 @@
+package com.zipup.server.global.security.exception;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OAuthProviderMissMatchException extends RuntimeException {
+    public OAuthProviderMissMatchException(String message) {
+        super(message);
+        log.error("OAuthProviderMissMatchException : {} ", message);
+    }
+}

--- a/src/main/java/com/zipup/server/global/security/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/zipup/server/global/security/filter/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.zipup.server.global.security.filter;
+
+import com.zipup.server.global.exception.CustomErrorCode;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private JSONObject responseJson = new JSONObject();
+
+  @Override
+  public void commence(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AuthenticationException authException) throws IOException {
+    CustomErrorCode exception = request.getAttribute("exception") == null
+            ? CustomErrorCode.UNKNOWN_ERROR
+            : (CustomErrorCode) request.getAttribute("exception");
+    setResponse(request, response, exception, authException);
+  }
+
+  private void setResponse(HttpServletRequest request, HttpServletResponse response, CustomErrorCode errorCode, AuthenticationException authException) throws IOException {
+    response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json;charset=UTF-8");
+
+    responseJson.put("message", errorCode.getMessage());
+    responseJson.put("code", errorCode.getCode());
+    responseJson.put("path", request.getContextPath() + request.getServletPath());
+    responseJson.put("auth_message", authException.getMessage());
+    responseJson.put("error_name", errorCode);
+
+    response.getWriter().print(responseJson);
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.zipup.server.global.security.filter;
+
+import com.zipup.server.global.security.util.JwtProvider;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.zipup.server.global.exception.CustomErrorCode.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+  private final JwtProvider jwtProvider;
+
+  private static final String[] AUTH_LIST = { "/api/v1/user/sign-up", "/api/v1/user/sign-in" };
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+          throws ServletException, IOException {
+    Map<String, String> cookieAttribute = request.getCookies() != null
+            ? Arrays.stream(request.getCookies()).collect(Collectors.toMap(Cookie::getName, Cookie::getValue))
+            : null;
+
+    String requestURI = request.getRequestURI();
+    String accessToken = jwtProvider.resolveToken(request) != null ? jwtProvider.resolveToken(request)
+            : cookieAttribute == null ? null
+            : cookieAttribute.get("Authorization") != null ? cookieAttribute.get("Authorization")
+            : null;
+
+    if (!StringUtils.hasText(accessToken) && Arrays.stream(AUTH_LIST).noneMatch(requestURI::contains))
+      request.setAttribute("exception", NOT_EXIST_TOKEN);
+
+    else if (StringUtils.hasText(accessToken) && Arrays.stream(AUTH_LIST).noneMatch(requestURI::contains)) {
+      try{
+        if (jwtProvider.validateToken(accessToken)) {
+          log.error("validateToken :: {} {} {}", NOT_EXIST_TOKEN.getMessage(), StringUtils.hasText(accessToken), requestURI);
+          request.setAttribute("exception", NOT_EXIST_TOKEN);
+        }
+
+        Authentication authentication = jwtProvider.getAuthenticationByToken(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      } catch (MalformedJwtException e){
+        request.setAttribute("exception", WRONG_TYPE_TOKEN);
+      } catch (JwtException e){
+        request.setAttribute("exception", EXPIRED_TOKEN);
+      } catch (RedisConnectionFailureException e) {
+        SecurityContextHolder.clearContext();
+        request.setAttribute("exception", REDIS_ERROR);
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/zipup/server/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/zipup/server/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.zipup.server.global.security.handler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+/**
+ * 유저 정보는 있으나 자원에 접근할 수 있는 권한이 없는 경우 : SC_FORBIDDEN (403) 응답
+ */
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+  @Override
+  public void handle(HttpServletRequest request,
+                     HttpServletResponse response,
+                     AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+  }
+}

--- a/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,42 @@
+package com.zipup.server.global.security.handler;
+
+import com.zipup.server.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.zipup.server.global.security.util.CookieUtil;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+    String targetUrl = CookieUtil.getCookie(request, HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue)
+            .orElse(("/"));
+
+    log.debug(exception.getMessage());
+
+    targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+            .queryParam("error", exception.getLocalizedMessage())
+            .build().toUriString();
+
+    authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,110 @@
+package com.zipup.server.global.security.handler;
+
+import com.zipup.server.global.util.entity.LoginProvider;
+import com.zipup.server.user.dto.SignInRequest;
+import com.zipup.server.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.zipup.server.global.security.oauth.info.OAuth2UserInfo;
+import com.zipup.server.global.security.oauth.info.OAuth2UserInfoFactory;
+import com.zipup.server.global.security.util.CookieUtil;
+import com.zipup.server.user.application.UserService;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static com.zipup.server.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository.*;
+import static com.zipup.server.global.security.util.CookieUtil.COOKIE_TOKEN_REFRESH;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final UserService userService;
+  private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+  @Value("${client.address}")
+  private String client;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    String targetUrl = determineTargetUrl(request, response, authentication);
+
+    if (response.isCommitted()) {
+      super.logger.error("Response has already been committed. Unable to redirect to " + targetUrl);
+      return;
+    }
+
+    clearAuthenticationAttributes(request, response);
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
+
+  protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+    Optional<String> redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue);
+
+    if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get()))
+      throw new IllegalArgumentException("리다이렉트 uri 에러 입니다. ::" + redirectUri);
+
+    String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+    OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+    LoginProvider providerType = LoginProvider.valueOf(authToken.getAuthorizedClientRegistrationId().toUpperCase());
+
+    OAuth2User user = ((OidcUser) authentication.getPrincipal());
+    OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+
+    SignInRequest req = SignInRequest.builder().email(userInfo.getEmail()).build();
+    HttpHeaders headers = userService.signIn(req);
+
+    List<String> accessTokenList = headers.get(HttpHeaders.AUTHORIZATION);
+    List<String> refreshTokenList = headers.get(REFRESH_TOKEN);
+
+    response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+
+    if ((accessTokenList != null ? accessTokenList.size() : 0) > 0) {
+      String accessToken = userService.resolveToken(accessTokenList.get(0));
+      CookieUtil.addResponseCookie(response, HttpHeaders.AUTHORIZATION, accessToken, COOKIE_EXPIRE_SECONDS, client);
+    }
+
+    if ((refreshTokenList != null ? refreshTokenList.size() : 0) > 0) {
+      String refreshToken = userService.resolveToken(refreshTokenList.get(0));
+      CookieUtil.addResponseCookie(response, COOKIE_TOKEN_REFRESH, refreshToken, COOKIE_EXPIRE_SECONDS, client);
+    }
+
+    return UriComponentsBuilder.fromUriString(targetUrl)
+            .build()
+            .encode(StandardCharsets.UTF_8)
+            .toUriString();
+  }
+
+  protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+    super.clearAuthenticationAttributes(request);
+    authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+  }
+
+  private boolean isAuthorizedRedirectUri(String uri) {
+    URI clientRedirectUri = URI.create(uri);
+    URI authorizedUri = URI.create(client);
+
+    return authorizedUri.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+            && authorizedUri.getPort() == clientRedirectUri.getPort();
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,79 @@
+package com.zipup.server.global.security.oauth;
+
+import com.zipup.server.user.domain.User;
+import com.zipup.server.global.util.entity.UserRole;
+import com.zipup.server.global.util.entity.LoginProvider;
+import com.zipup.server.user.infrastructure.UserRepository;
+import com.zipup.server.global.security.exception.OAuthProviderMissMatchException;
+import com.zipup.server.global.security.oauth.info.OAuth2UserInfo;
+import com.zipup.server.global.security.oauth.info.OAuth2UserInfoFactory;
+import com.zipup.server.global.util.entity.LoginProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private static final String ALREADY_SIGNED_UP_SOCIAL = "already_signed_up_social";
+  private static final String ALREADY_SIGNED_UP_LOCAL = "already_signed_up_local";
+
+  private final UserRepository userRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User user = super.loadUser(userRequest);
+
+    try {
+      return this.process(userRequest, user);
+    } catch (AuthenticationException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      log.error("CustomOAuth2UserService loadUser Error: {} ", ex.getMessage());
+      throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+    }
+  }
+
+  private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User user) {
+    LoginProvider providerType = LoginProvider.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+
+    OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+    User targetUser = userRepository.findUserByEmail(userInfo.getEmail());
+
+    if (targetUser != null) {
+      if (targetUser.getLoginProvider() == LoginProvider.LOCAL){
+        log.error("CustomOAuth2UserService process Error: 기존 회원입니다. 자체 로그인을 이용해 주세요. ");
+        throw new OAuthProviderMissMatchException(ALREADY_SIGNED_UP_LOCAL);
+      }
+
+      if (providerType != targetUser.getLoginProvider()) {
+        log.error("CustomOAuth2UserService process Error: 다른 소셜에서 가입된 이메일 입니다. 해당 소셜 로그인을 이용해 주세요.");
+        throw new OAuthProviderMissMatchException(ALREADY_SIGNED_UP_SOCIAL);
+      }
+    }
+    else targetUser = createUser(userInfo, providerType);
+
+    return UserPrincipal.create(targetUser, user.getAttributes());
+  }
+
+  private User createUser(OAuth2UserInfo userInfo, LoginProvider providerType) {
+    User user = User.builder()
+            .email(userInfo.getEmail())
+            .name(userInfo.getName())
+            .password("")
+            .loginProvider(providerType)
+            .role(UserRole.USER)
+            .build();
+
+    return userRepository.saveAndFlush(user);
+  }
+
+}

--- a/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,69 @@
+package com.zipup.server.global.security.oauth;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import com.zipup.server.global.security.util.CookieUtil;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+  public final static String REFRESH_TOKEN = HttpHeaders.AUTHORIZATION + "_REFRESH";
+  public static final int COOKIE_EXPIRE_SECONDS = 180;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> {
+              try {
+                return CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class);
+              } catch (IllegalArgumentException | IOException | ClassNotFoundException e) {
+                log.error(e.getMessage());
+                log.error(e.getClass().getName());
+                return null;
+              }
+            })
+            .orElse(null);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      CookieUtil.deleteCookie(request, response, HttpHeaders.AUTHORIZATION);
+      CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+      CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+      return;
+    }
+
+    CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+    String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+    if (StringUtils.isNotBlank(redirectUriAfterLogin))
+      CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+    return this.loadAuthorizationRequest(request);
+  }
+
+  public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+    CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+  }
+
+}
+

--- a/src/main/java/com/zipup/server/global/security/oauth/UserPrincipal.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/UserPrincipal.java
@@ -1,0 +1,108 @@
+package com.zipup.server.global.security.oauth;
+
+import com.zipup.server.user.domain.User;
+import com.zipup.server.global.util.entity.LoginProvider;
+import com.zipup.server.global.util.entity.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UserPrincipal implements OAuth2User, UserDetails, OidcUser {
+
+	private final String email;
+	private final String nickname;
+	private final String password;
+	private final LoginProvider providerType;
+	private final UserRole roleType;
+	private final Collection<GrantedAuthority> authorities;
+	private Map<String, Object> attributes;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getName() {
+		return email;
+	}
+
+	@Override
+	public String getUsername() {
+		return nickname;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public Map<String, Object> getClaims() {
+		return null;
+	}
+
+	@Override
+	public OidcUserInfo getUserInfo() {
+		return null;
+	}
+
+	@Override
+	public OidcIdToken getIdToken() {
+		return null;
+	}
+
+	private static UserPrincipal create(User user) {
+		return new UserPrincipal(
+						user.getEmail(),
+						user.getName(),
+						user.getPassword(),
+						user.getLoginProvider(),
+						UserRole.USER,
+						Collections.singletonList(new SimpleGrantedAuthority(UserRole.USER.getValue()))
+		);
+	}
+
+	public static UserPrincipal create(User user, Map<String, Object> attributes) {
+		UserPrincipal userPrincipal = create(user);
+		userPrincipal.setAttributes(attributes);
+
+		return userPrincipal;
+	}
+}

--- a/src/main/java/com/zipup/server/global/security/oauth/info/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/info/KakaoOAuth2UserInfo.java
@@ -1,0 +1,51 @@
+package com.zipup.server.global.security.oauth.info;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+	public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> Map<String, T> getProperties(Map<String, Object> attributes) {
+		return (Map<String, T>) attributes.get("properties");
+	}
+
+	@Override
+	public String getId() {
+		return attributes.get("id").toString();
+	}
+
+	@Override
+	public String getName() {
+		Map<String, Object> properties = getProperties(attributes);
+
+		if (properties == null) return null;
+
+		return (String) properties.get("nickname");
+	}
+
+	@Override
+	public String getImageUrl() {
+		Map<String, Object> properties = getProperties(attributes);
+
+		if (properties == null) return null;
+
+		return (String) properties.get("profile_image");
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> Map<String, T> getAccounts(Map<String, Object> attributes) {
+		return (Map<String, T>) attributes.get("kakao_account");
+	}
+
+	@Override
+	public String getEmail() {
+		Map<String, Object> account = getAccounts(attributes);
+
+		return (String) account.get("email");
+	}
+
+}

--- a/src/main/java/com/zipup/server/global/security/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/info/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.zipup.server.global.security.oauth.info;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+	protected Map<String, Object> attributes;
+
+	public OAuth2UserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public abstract String getId();
+
+	public abstract String getName();
+
+	public abstract String getEmail();
+
+	public abstract String getImageUrl();
+}

--- a/src/main/java/com/zipup/server/global/security/oauth/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/info/OAuth2UserInfoFactory.java
@@ -1,0 +1,15 @@
+package com.zipup.server.global.security.oauth.info;
+
+import com.zipup.server.global.util.entity.LoginProvider;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+	public static OAuth2UserInfo getOAuth2UserInfo(LoginProvider providerType, Map<String, Object> attributes) {
+		if (providerType == LoginProvider.KAKAO) {
+			return new KakaoOAuth2UserInfo(attributes);
+		} else {
+			throw new IllegalArgumentException("Invalid Provider Type.");
+		}
+	}
+}

--- a/src/main/java/com/zipup/server/global/security/util/CookieUtil.java
+++ b/src/main/java/com/zipup/server/global/security/util/CookieUtil.java
@@ -1,0 +1,112 @@
+package com.zipup.server.global.security.util;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.SerializationUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+public class CookieUtil {
+  public static final String COOKIE_TOKEN_REFRESH = "refresh-token";
+
+  public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName()))
+          return Optional.of(cookie);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(maxAge);
+
+    response.addCookie(cookie);
+  }
+
+  public static ResponseCookie addResponseCookie(String name, String value, int maxAge) {
+    return ResponseCookie.from(name, value)
+            .maxAge(maxAge)
+            .sameSite("None")
+            .secure(true)
+            .httpOnly(true)
+            .path("/")
+            .build();
+  }
+
+  public static ResponseCookie addResponseCookie(HttpServletResponse response, String name, String value, int maxAge, String url) {
+    String domain = extractDomain(url);
+
+    ResponseCookie cookie = ResponseCookie.from(name, value)
+            .maxAge(maxAge)
+            .sameSite("None")
+            .secure(true)
+            .httpOnly(true)
+            .path("/")
+            .domain(domain)
+            .build();
+
+    response.addHeader(SET_COOKIE, cookie.toString());
+
+    return cookie;
+  }
+
+  public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName())) {
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+
+  public static String serialize(Object obj) {
+    return Base64.getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(obj));
+  }
+
+  public static <T> T deserialize(Cookie cookie, Class<T> cls) throws IOException, ClassNotFoundException {
+    return cls.cast(deserializeWithObjectInputStream(Base64.getUrlDecoder().decode(cookie.getValue())));
+  }
+
+  private static Object deserializeWithObjectInputStream(byte[] bytes) throws IOException, ClassNotFoundException {
+    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+         ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+      return objectInputStream.readObject();
+    }
+  }
+
+  private static String extractDomain(String url) {
+    try {
+      URI uri = new URI(url);
+      String domain = uri.getHost();
+      return domain.startsWith("www.") ? domain.substring(4) : domain;
+    } catch (URISyntaxException e) {
+      return "";
+    }
+  }
+
+}
+

--- a/src/main/java/com/zipup/server/global/security/util/JwtProvider.java
+++ b/src/main/java/com/zipup/server/global/security/util/JwtProvider.java
@@ -1,0 +1,201 @@
+package com.zipup.server.global.security.util;
+
+import com.zipup.server.global.exception.BaseException;
+import com.zipup.server.user.dto.TokenResponse;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.Keys;
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.zipup.server.global.exception.CustomErrorCode.ACCESS_DENIED;
+import static com.zipup.server.global.exception.CustomErrorCode.EXPIRED_TOKEN;
+import static com.zipup.server.global.exception.CustomErrorCode.UNSUPPORTED_TOKEN;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Getter
+public class JwtProvider {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${spring.jwt.secret}")
+    private String key;
+
+    @Value("${spring.jwt.token.access-expiration-time}")
+    private long accessExpirationTime;
+
+    @Value("${spring.jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
+
+    @Value("${spring.jwt.header}")
+    private String accessHeader;
+
+    @Value("${spring.jwt.prefix}")
+    private String prefix;
+
+    private final String refresh = "_REFRESH";
+
+    private Key secretKey;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(key);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenResponse generateToken(String id, String role) {
+        Claims claims = Jwts.claims().setId(id);
+        claims.put("role", role);
+
+        String accessToken = generateAccessToken(claims);
+        String refreshToken = generateRefreshToken(claims);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public String generateAccessToken(Claims claims) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + accessExpirationTime);
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(secretKey, SignatureAlgorithm.HS512)
+                .compact();
+
+        redisTemplate.opsForValue().set(
+                claims.getId(),
+                accessToken,
+                accessExpirationTime,
+                TimeUnit.MILLISECONDS
+        );
+
+        return accessToken;
+    }
+
+    public String generateRefreshToken(Claims claims) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + refreshExpirationTime);
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(secretKey, SignatureAlgorithm.HS512)
+                .compact();
+
+        redisTemplate.opsForValue().set(
+                claims.getId() + refresh,
+                refreshToken,
+                refreshExpirationTime,
+                TimeUnit.MILLISECONDS
+        );
+
+        return refreshToken;
+    }
+
+    /**
+     * 토큰으로부터 클레임을 만들고, 이를 통해 User 객체 생성해 Authentication 객체 반환
+     */
+    public Authentication getAuthenticationByToken(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if(claims.get("role") == null) throw new AccessDeniedException(ACCESS_DENIED.getMessage());
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("role").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getId(),"", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(accessHeader);
+        if (StringUtils.hasText(accessToken) && accessToken.startsWith(prefix)) {
+            return accessToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey) // 비밀키를 설정하여 파싱한다.
+                    .build()
+                    .parseClaimsJws(token);  // 주어진 토큰을 파싱하여 Claims 객체를 얻는다.
+
+            // 토큰의 만료 시간과 현재 시간비교
+            return !claims.getBody()
+                    .getExpiration()
+                    .after(new Date());  // 만료 시간이 현재 시간 이후인지 확인하여 유효성 검사 결과를 반환
+        } catch (ExpiredJwtException e) {
+            log.error("토큰 이슈 = {}", token);
+            log.error("메시지 = {}", e.getMessage());
+            log.error("에러 종류 = {}", e.getClass());
+            throw new JwtException(EXPIRED_TOKEN.getMessage());
+        }
+    }
+
+    public HttpHeaders setTokenHeaders(TokenResponse tokenResponse) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(accessHeader, prefix + " " + tokenResponse.getAccessToken());
+        headers.add(accessHeader + refresh, prefix + " " + tokenResponse.getRefreshToken());
+        return headers;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public void verifyRefreshToken(String refreshToken) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(refreshToken);
+        } catch (DecodingException e) {
+            throw new BaseException(UNSUPPORTED_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new BaseException(EXPIRED_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/zipup/server/global/util/entity/UserRole.java
+++ b/src/main/java/com/zipup/server/global/util/entity/UserRole.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserRole implements BaseEnumCode<String> {
-  ADMIN("관리자"), USER("회원"), GUEST("비회원");
+  ADMIN("ROLE_ADMIN", "관리자"), USER("ROLE_USER", "회원"), GUEST("ROLE_GUEST", "비회원");
 
+  private final String key;
   private final String value;
 
   @Override

--- a/src/main/java/com/zipup/server/user/application/AuthService.java
+++ b/src/main/java/com/zipup/server/user/application/AuthService.java
@@ -1,0 +1,52 @@
+package com.zipup.server.user.application;
+
+import com.zipup.server.user.dto.TokenResponse;
+import com.zipup.server.global.exception.BaseException;
+import com.zipup.server.global.security.util.CookieUtil;
+import com.zipup.server.global.security.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.zipup.server.global.exception.CustomErrorCode.NOT_EXIST_TOKEN;
+import static com.zipup.server.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository.COOKIE_EXPIRE_SECONDS;
+import static com.zipup.server.global.security.util.CookieUtil.COOKIE_TOKEN_REFRESH;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final JwtProvider jwtProvider;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Transactional
+  public ResponseCookie[] refresh(String refreshToken) {
+    jwtProvider.verifyRefreshToken(refreshToken);
+
+    Authentication authentication = jwtProvider.getAuthenticationByToken(refreshToken);
+    String redisRefreshToken = redisTemplate.opsForValue().get(authentication.getName() + "_REFRESH");
+
+    if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken))
+      throw new BaseException(NOT_EXIST_TOKEN);
+
+    TokenResponse newToken = jwtProvider.generateToken(
+            authentication.getName(),
+            authentication.getAuthorities().stream()
+                    .findFirst()
+                    .orElseThrow(IllegalAccessError::new)
+                    .getAuthority()
+    );
+
+    return new ResponseCookie[] {
+            CookieUtil.addResponseCookie(HttpHeaders.AUTHORIZATION, newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
+            CookieUtil.addResponseCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS)
+    };
+  }
+
+}

--- a/src/main/java/com/zipup/server/user/application/UserService.java
+++ b/src/main/java/com/zipup/server/user/application/UserService.java
@@ -2,11 +2,15 @@ package com.zipup.server.user.application;
 
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.global.security.util.JwtProvider;
+import com.zipup.server.global.util.entity.UserRole;
 import com.zipup.server.user.domain.User;
 import com.zipup.server.user.dto.SignInRequest;
+import com.zipup.server.user.dto.SignInResponse;
+import com.zipup.server.user.dto.SignUpRequest;
 import com.zipup.server.user.dto.TokenResponse;
 import com.zipup.server.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +31,29 @@ public class UserService {
   public User findByEmail(String email) {
     return userRepository.findByEmail(email)
             .orElseThrow(() -> new NoResultException("존재하지 않는 회원이에요."));
+  }
+
+  @SneakyThrows
+  @Transactional
+  public SignInResponse signUp(SignUpRequest request) {
+    User user = createUser(request);
+
+    return SignInResponse.builder()
+            .id(user.getId())
+            .email(user.getEmail())
+            .name(user.getName())
+            .build();
+  }
+
+  @Transactional
+  public User createUser(SignUpRequest request) {
+    User user = User.builder()
+            .email(request.getEmail())
+            .name(request.getName())
+            .password(request.getPassword())
+            .role(UserRole.USER)
+            .build();
+    return userRepository.save(user);
   }
 
   @Transactional

--- a/src/main/java/com/zipup/server/user/application/UserService.java
+++ b/src/main/java/com/zipup/server/user/application/UserService.java
@@ -1,13 +1,47 @@
 package com.zipup.server.user.application;
 
+import com.zipup.server.global.exception.BaseException;
+import com.zipup.server.global.security.util.JwtProvider;
+import com.zipup.server.user.domain.User;
+import com.zipup.server.user.dto.SignInRequest;
+import com.zipup.server.user.dto.TokenResponse;
 import com.zipup.server.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.NoResultException;
+
+import static com.zipup.server.global.exception.CustomErrorCode.TOKEN_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
   private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
+
+  @Transactional(readOnly = true)
+  public User findByEmail(String email) {
+    return userRepository.findByEmail(email)
+            .orElseThrow(() -> new NoResultException("존재하지 않는 회원이에요."));
+  }
+
+  @Transactional
+  public HttpHeaders signIn(SignInRequest request) {
+    User targetUser = findByEmail(request.getEmail());
+    TokenResponse token = jwtProvider.generateToken(targetUser.getId().toString(), targetUser.getRole().getKey());
+    return jwtProvider.setTokenHeaders(token);
+  }
+
+  public String resolveToken(String tokenInHeader) {
+
+    if (StringUtils.hasText(tokenInHeader) && tokenInHeader.startsWith(jwtProvider.getPrefix())) {
+      return tokenInHeader.substring(7);
+    }
+    else throw new BaseException(TOKEN_NOT_FOUND);
+  }
 
 }

--- a/src/main/java/com/zipup/server/user/domain/User.java
+++ b/src/main/java/com/zipup/server/user/domain/User.java
@@ -31,7 +31,11 @@ public class User extends BaseTimeEntity {
   @Convert(converter = StringToUuidConverter.class)
   private UUID id;
 
+  @Column
   private String name;
+
+  @Column
+  private String password;
 
   @Column(nullable = false, unique = true)
   @Email(message = "메일 형식에 맞춰 작성해주세요",
@@ -43,7 +47,7 @@ public class User extends BaseTimeEntity {
   private UserRole role;
 
   @Enumerated(EnumType.STRING)
-  private LoginProvider socialProvider;
+  private LoginProvider loginProvider;
 
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   private List<Fund> funds;

--- a/src/main/java/com/zipup/server/user/dto/SignInRequest.java
+++ b/src/main/java/com/zipup/server/user/dto/SignInRequest.java
@@ -1,0 +1,15 @@
+package com.zipup.server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignInRequest {
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/zipup/server/user/dto/SignInResponse.java
+++ b/src/main/java/com/zipup/server/user/dto/SignInResponse.java
@@ -1,0 +1,14 @@
+package com.zipup.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SignInResponse {
+  private UUID id;
+  private String name;
+  private String email;
+}

--- a/src/main/java/com/zipup/server/user/dto/SignUpRequest.java
+++ b/src/main/java/com/zipup/server/user/dto/SignUpRequest.java
@@ -1,0 +1,19 @@
+package com.zipup.server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignUpRequest {
+  private String name;
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/zipup/server/user/dto/TokenResponse.java
+++ b/src/main/java/com/zipup/server/user/dto/TokenResponse.java
@@ -1,0 +1,15 @@
+package com.zipup.server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenResponse {
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/zipup/server/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/zipup/server/user/infrastructure/UserRepository.java
@@ -4,8 +4,12 @@ import com.zipup.server.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
+  Optional<User> findByEmail(String email);
+
+  User findUserByEmail(String email);
 }

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -1,0 +1,34 @@
+package com.zipup.server.user.presentation;
+
+import com.zipup.server.user.application.AuthService;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.zipup.server.global.security.util.CookieUtil.COOKIE_TOKEN_REFRESH;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refresh(
+            @CookieValue(COOKIE_TOKEN_REFRESH) final String refreshToken,
+            final HttpServletResponse httpServletResponse
+    ) {
+        ResponseCookie[] newToken = authService.refresh(refreshToken);
+        httpServletResponse.addHeader(SET_COOKIE, newToken[0].toString());
+        httpServletResponse.addHeader(SET_COOKIE, newToken[1].toString());
+
+        return ResponseEntity.status(CREATED).build();
+    }
+}

--- a/src/main/java/com/zipup/server/user/presentation/UserController.java
+++ b/src/main/java/com/zipup/server/user/presentation/UserController.java
@@ -1,10 +1,17 @@
 package com.zipup.server.user.presentation;
 
 import com.zipup.server.user.application.UserService;
+import com.zipup.server.user.dto.SignInRequest;
+import com.zipup.server.user.dto.SignInResponse;
+import com.zipup.server.user.dto.SignUpRequest;
+import com.zipup.server.user.dto.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/user")
@@ -14,5 +21,20 @@ public class UserController {
 
   private final UserService userService;
 
+  @PostMapping("/sign-up")
+  public ResponseEntity<SignInResponse> signUp(
+          @Valid @RequestPart("request") SignUpRequest request
+  ) {
+    SignInResponse response = userService.signUp(request);
+    HttpHeaders headers = userService.signIn(SignInRequest.builder().email(response.getEmail()).build());
+
+    return ResponseEntity.ok().headers(headers).body(response);
+  }
+
+  @PostMapping("/sign-in")
+  public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody SignInRequest request) {
+    HttpHeaders headers = userService.signIn(request);
+    return ResponseEntity.ok().headers(headers).build();
+  }
 
 }


### PR DESCRIPTION
|name| about       |
|------|-------------|
|FEATURE_REPORT| 카카오 소셜 로그인 구현   |


## 💡 구현할 기능 설명
- 카카오 소셜 로그인 1차로 구현
- SecurityConfig로 filter chain 구현 
- Token 관리용 클래스 구현 
- Redis 연동

## ❗체크리스트
- [x] 소셜 로그인 구현
- [ ] 테스트 코드 구현
- [ ] 프론트랑 통신