### PR TITLE
[fix] #19 펀딩 상세 조회 API 수정

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -7,7 +7,6 @@ import com.zipup.server.funding.dto.FundingSummaryResponse;
 import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.funding.infrastructure.FundRepository;
 import com.zipup.server.user.application.UserService;
-import com.zipup.server.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,9 +40,8 @@ public class FundService {
 
   @Transactional
   public SimpleDataResponse createFunding(CreateFundingRequest request) {
-    User user = userService.findById(request.getUser());
     Fund targetFund = request.toEntity();
-    targetFund.setUser(user);
+    targetFund.setUser(userService.findById(request.getUser()));
 
     Fund response = fundRepository.save(targetFund);
 
@@ -59,9 +57,13 @@ public class FundService {
             .collect(Collectors.toList());
   }
 
-  public FundingDetailResponse getFundingDetail(String id) {
-    isValidUUID(id);
-    return findById(id).toDetailResponse();
+  public FundingDetailResponse getFundingDetail(String fundId, String userId) {
+    isValidUUID(fundId);
+    isValidUUID(userId);
+
+    Fund targetFunding = findById(fundId);
+
+    return targetFunding.toDetailResponse(userService.findById(userId).equals(targetFunding.getUser()));
   }
 
 }

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -92,7 +92,7 @@ public class Fund extends BaseTimeEntity {
             .build();
   }
 
-  public FundingDetailResponse toDetailResponse() {
+  public FundingDetailResponse toDetailResponse(Boolean isOrganizer) {
     long duration = Duration.between(LocalDateTime.now(), fundingPeriod.getFinishFunding()).toDays();
     int nowPresent = presents.stream()
             .mapToInt(present -> present.getPayment().getPrice())
@@ -107,6 +107,7 @@ public class Fund extends BaseTimeEntity {
             .goalPrice(goalPrice)
             .percent(nowPresent / goalPrice)
             .presentList(presents.stream().map(Present::toSummaryResponse).collect(Collectors.toList()))
+            .isOrganizer(isOrganizer)
             .build();
   }
 

--- a/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
+++ b/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
@@ -21,4 +21,5 @@ public class FundingDetailResponse {
   private Integer goalPrice;
   @Schema(description = "해당 펀딩에 참여한 사람 목록")
   private List<PresentSummaryResponse> presentList;
+  private Boolean isOrganizer;
 }

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,15 +52,25 @@ public class FundController {
     return ResponseEntity.ok(fundService.getMyFundingList(userId));
   }
 
-  @Operation(summary = "내가 주최한 펀딩 상세 조회", description = "펀딩 상세 내용")
+  @Operation(summary = "펀딩 페이지 상세 조회", description = "펀딩 상세 내용")
   @Parameter(name = "funding", description = "선택한 펀딩의 식별자 값 (UUID)")
-  @ApiResponse(
-          responseCode = "200",
-          description = "조회 성공",
-          content = @Content(schema = @Schema(implementation = FundingDetailResponse.class)))
+  @Parameter(name = "user", description = "진입한 유저의 식별자 값 (UUID)")
+  @ApiResponses(value = {
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "조회 성공",
+                  content = @Content(schema = @Schema(implementation = FundingDetailResponse.class))),
+          @ApiResponse(
+                  responseCode = "400",
+                  description = "잘못된 UUID 형태",
+                  content = @Content(schema = @Schema(type = "유효하지 않은 UUID입니다: {요청 인자}")))
+  })
   @GetMapping("")
-  public ResponseEntity<FundingDetailResponse> getFundingDetail(@RequestParam(value = "funding") String id) {
-    return ResponseEntity.ok(fundService.getFundingDetail(id));
+  public ResponseEntity<FundingDetailResponse> getFundingDetail(
+          @RequestParam(value = "funding") String fundId,
+          @RequestParam(value = "user") String userId
+  ) {
+    return ResponseEntity.ok(fundService.getFundingDetail(fundId, userId));
   }
 
   @Operation(summary = "펀딩 주최", description = "펀딩 주최")

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -22,19 +22,6 @@ public class PresentService {
   private final PaymentService paymentService;
   private final PresentRepository presentRepository;
 
-  private void isValidUUID(String id) {
-    try {
-      UUID.fromString(id);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("유효하지 않은 UUID입니다: " + id);
-    }
-  }
-
-  public FundingDetailResponse getFundingDetail(String id) {
-    isValidUUID(id);
-    return fundService.getFundingDetail(id);
-  }
-
   @Transactional
   public String participateFunding(ParticipatePresentRequest request) {
     String fundingId = request.getFundingId();

--- a/src/main/java/com/zipup/server/present/presentation/PresentController.java
+++ b/src/main/java/com/zipup/server/present/presentation/PresentController.java
@@ -23,23 +23,6 @@ import org.springframework.web.bind.annotation.*;
 public class PresentController {
   private final PresentService presentService;
 
-  @Operation(summary = "참여할 펀딩 조회", description = "펀딩 식별자 값으로 참여할 펀딩 조회")
-  @Parameter(name = "funding", description = "펀딩 식별자 값 (UUID)")
-  @ApiResponses(value = {
-          @ApiResponse(
-                  responseCode = "200",
-                  description = "조회 성공",
-                  content = @Content(schema = @Schema(implementation = FundingDetailResponse.class))),
-          @ApiResponse(
-                  responseCode = "400",
-                  description = "잘못된 UUID 형태",
-                  content = @Content(schema = @Schema(type = "유효하지 않은 UUID입니다: {요청 인자}")))
-  })
-  @GetMapping("")
-  public ResponseEntity<FundingDetailResponse> getFundingDetail(@RequestParam(value = "funding") String id) {
-    return ResponseEntity.ok(presentService.getFundingDetail(id));
-  }
-
   @Operation(summary = "펀딩 참여하기", description = "펀딩 식별자 값으로 참여할 펀딩 조회")
   @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "펀딩, 참여자, 결제 내역에 대한 식별자 값과 보내는 사람 이름 & 축하 메시지")
   @ApiResponses(value = {


### PR DESCRIPTION
## 💡 구현할 기능 설명
펀딩 상세 페이지 조회 시,

기존 : 주최자 / 참여자 각각 API 존재
변경 : 하나의 API로 통일하고 주최자 여부 값 Boolean으로 담아서 응답
하는 방식으로 변경