### PR TITLE
[fix] 전체 회원, 펀딩 UUID 확인 용 임시 API

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -7,6 +7,7 @@ import com.zipup.server.funding.dto.FundingSummaryResponse;
 import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.funding.infrastructure.FundRepository;
 import com.zipup.server.user.application.UserService;
+import com.zipup.server.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,4 +67,10 @@ public class FundService {
     return targetFunding.toDetailResponse(userService.findById(userId).equals(targetFunding.getUser()));
   }
 
+  public List<FundingSummaryResponse> getFundList() {
+    return fundRepository.findAll()
+            .stream()
+            .map(Fund::toSummaryResponse)
+            .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -2,6 +2,7 @@ package com.zipup.server.funding.domain;
 
 import com.zipup.server.funding.dto.FundingDetailResponse;
 import com.zipup.server.funding.dto.FundingSummaryResponse;
+import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.util.converter.StringToUuidConverter;
 import com.zipup.server.global.util.entity.*;
 import com.zipup.server.present.domain.Present;
@@ -74,8 +75,11 @@ public class Fund extends BaseTimeEntity {
   @Setter
   private User user;
 
-  @OneToMany(mappedBy = "fund", fetch = FetchType.LAZY)
+  @OneToMany(
+          mappedBy = "fund"
+          , fetch = FetchType.EAGER)
   private List<Present> presents;
+
 
   public FundingSummaryResponse toSummaryResponse() {
     long duration = Duration.between(LocalDateTime.now(), fundingPeriod.getFinishFunding()).toDays();
@@ -88,7 +92,8 @@ public class Fund extends BaseTimeEntity {
             .title(title)
             .imageUrl(imageUrl)
             .status(duration > 0 ? "D-" + duration : "완료")
-            .percent(nowPresent / goalPrice)
+            .percent((int) (((double) nowPresent / goalPrice) * 100))
+            .organizer(user.getId().toString())
             .build();
   }
 
@@ -108,6 +113,13 @@ public class Fund extends BaseTimeEntity {
             .percent(nowPresent / goalPrice)
             .presentList(presents.stream().map(Present::toSummaryResponse).collect(Collectors.toList()))
             .isOrganizer(isOrganizer)
+            .organizer(user.getId().toString())
+            .build();
+  }
+
+  public SimpleDataResponse toSimpleDataResponse() {
+    return SimpleDataResponse.builder()
+            .id(id.toString())
             .build();
   }
 

--- a/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
+++ b/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
@@ -22,4 +22,5 @@ public class FundingDetailResponse {
   @Schema(description = "해당 펀딩에 참여한 사람 목록")
   private List<PresentSummaryResponse> presentList;
   private Boolean isOrganizer;
+  private String organizer;
 }

--- a/src/main/java/com/zipup/server/funding/dto/FundingSummaryResponse.java
+++ b/src/main/java/com/zipup/server/funding/dto/FundingSummaryResponse.java
@@ -11,4 +11,5 @@ public class FundingSummaryResponse {
   private String imageUrl;
   private String status;
   private Integer percent;
+  private String organizer;
 }

--- a/src/main/java/com/zipup/server/funding/dto/SimpleDataResponse.java
+++ b/src/main/java/com/zipup/server/funding/dto/SimpleDataResponse.java
@@ -1,11 +1,13 @@
 package com.zipup.server.funding.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Data
 @RequiredArgsConstructor
+@Builder
 public class SimpleDataResponse {
   @Schema(description = "펀딩 식별자 값 (UUID)")
   private final String id;

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -92,4 +92,11 @@ public class FundController {
     return ResponseEntity.created(location).build();
   }
 
+  @Operation(summary = "임시 데이터", description = "임시")
+  @GetMapping("/temp")
+  public ResponseEntity<List<FundingSummaryResponse>> getFundList() {
+    List<FundingSummaryResponse> response = fundService.getFundList();
+    return ResponseEntity.ok(response);
+  }
+
 }

--- a/src/main/java/com/zipup/server/payment/domain/Payment.java
+++ b/src/main/java/com/zipup/server/payment/domain/Payment.java
@@ -46,7 +46,7 @@ public class Payment extends BaseTimeEntity {
   @NotNull(message = "결제 수단 누락")
   private String paymentMethod;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @Transient
   private Present present;
 
 }

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -1,18 +1,23 @@
 package com.zipup.server.present.application;
 
 import com.zipup.server.funding.application.FundService;
+import com.zipup.server.funding.domain.Fund;
 import com.zipup.server.funding.dto.FundingDetailResponse;
+import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.payment.application.PaymentService;
 import com.zipup.server.payment.domain.Payment;
 import com.zipup.server.present.domain.Present;
 import com.zipup.server.present.dto.ParticipatePresentRequest;
+import com.zipup.server.present.dto.PresentSummaryResponse;
 import com.zipup.server.present.infrastructure.PresentRepository;
 import com.zipup.server.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +46,13 @@ public class PresentService {
 
     presentRepository.save(participateFunding);
     return participateFunding.getId().toString();
+  }
+
+  public List<PresentSummaryResponse> getParticipateList() {
+    return presentRepository.findAll()
+            .stream()
+            .map(Present::toSummaryResponse)
+            .collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/com/zipup/server/present/domain/Present.java
+++ b/src/main/java/com/zipup/server/present/domain/Present.java
@@ -1,6 +1,7 @@
 package com.zipup.server.present.domain;
 
 import com.zipup.server.funding.domain.Fund;
+import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.util.converter.StringToUuidConverter;
 import com.zipup.server.global.util.entity.BaseTimeEntity;
 import com.zipup.server.payment.domain.Payment;
@@ -11,11 +12,10 @@ import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "present")
+@Table(name = "presents")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -36,27 +36,32 @@ public class Present extends BaseTimeEntity {
   @Column
   private String congratsMessage;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "user_id")
   @Setter
   private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "fund_id")
   @Setter
   private Fund fund;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @OneToOne(fetch = FetchType.EAGER)
   private Payment payment;
 
   public PresentSummaryResponse toSummaryResponse() {
     return PresentSummaryResponse.builder()
             .id(id.toString())
             .senderName(senderName)
-            .profileImage(user.getProfileImage())
+            .profileImage(user.getProfileImage() != null ? user.getProfileImage() : "")
             .congratsMessage(congratsMessage)
-            .contributionPercent(payment.getPrice() / fund.getGoalPrice())
+            .contributionPercent((int) ((double) payment.getPrice() / fund.getGoalPrice()) * 100)
             .build();
   }
 
+  public SimpleDataResponse toSimpleDataResponse() {
+    return SimpleDataResponse.builder()
+            .id(id.toString())
+            .build();
+  }
 }

--- a/src/main/java/com/zipup/server/present/presentation/PresentController.java
+++ b/src/main/java/com/zipup/server/present/presentation/PresentController.java
@@ -1,8 +1,11 @@
 package com.zipup.server.present.presentation;
 
 import com.zipup.server.funding.dto.FundingDetailResponse;
+import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.present.application.PresentService;
 import com.zipup.server.present.dto.ParticipatePresentRequest;
+import com.zipup.server.present.dto.PresentSummaryResponse;
+import com.zipup.server.user.dto.UserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/present")
@@ -38,5 +43,12 @@ public class PresentController {
   @PostMapping("")
   public ResponseEntity<String> participateFunding(@RequestBody ParticipatePresentRequest request) {
     return ResponseEntity.ok(presentService.participateFunding(request));
+  }
+
+  @Operation(summary = "임시 데이터", description = "임시")
+  @GetMapping("/temp")
+  public ResponseEntity<List<PresentSummaryResponse>> getParticipateList() {
+    List<PresentSummaryResponse> response = presentService.getParticipateList();
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/zipup/server/user/application/UserService.java
+++ b/src/main/java/com/zipup/server/user/application/UserService.java
@@ -4,10 +4,7 @@ import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.global.security.util.JwtProvider;
 import com.zipup.server.global.util.entity.UserRole;
 import com.zipup.server.user.domain.User;
-import com.zipup.server.user.dto.SignInRequest;
-import com.zipup.server.user.dto.SignInResponse;
-import com.zipup.server.user.dto.SignUpRequest;
-import com.zipup.server.user.dto.TokenResponse;
+import com.zipup.server.user.dto.*;
 import com.zipup.server.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -18,7 +15,9 @@ import org.springframework.util.StringUtils;
 
 import javax.persistence.NoResultException;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.zipup.server.global.exception.CustomErrorCode.TOKEN_NOT_FOUND;
 
@@ -88,6 +87,10 @@ public class UserService {
     else throw new BaseException(TOKEN_NOT_FOUND);
   }
 
-
-
+  public List<UserListResponse> getUserList() {
+    return userRepository.findAll()
+            .stream()
+            .map(User::toResponseList)
+            .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/zipup/server/user/domain/User.java
+++ b/src/main/java/com/zipup/server/user/domain/User.java
@@ -1,12 +1,14 @@
 package com.zipup.server.user.domain;
 
 import com.zipup.server.funding.domain.Fund;
+import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.util.entity.BaseTimeEntity;
 import com.zipup.server.global.util.entity.LoginProvider;
 import com.zipup.server.global.util.entity.UserRole;
 import com.zipup.server.global.util.converter.StringToUuidConverter;
 import com.zipup.server.present.domain.Present;
 import com.zipup.server.review.domain.Review;
+import com.zipup.server.user.dto.UserListResponse;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 
@@ -15,6 +17,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "users")
@@ -52,13 +55,40 @@ public class User extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private LoginProvider loginProvider;
 
-  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+  @OneToMany(
+          mappedBy = "user"
+          , fetch = FetchType.LAZY
+          , cascade = CascadeType.PERSIST
+          , orphanRemoval = true
+  )
   private List<Fund> funds;
 
-  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+  @OneToMany(
+          mappedBy = "user"
+          , fetch = FetchType.LAZY
+          , cascade = CascadeType.PERSIST
+          , orphanRemoval = true
+  )
   private List<Present> presents;
 
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   private List<Review> reviews;
+
+  public UserListResponse toResponseList() {
+    return UserListResponse.builder()
+            .id(id.toString())
+            .name(name)
+            .email(email)
+//            .fundList(funds.stream().map(Fund::toSimpleDataResponse).collect(Collectors.toList()))
+//            .presentList(presents.stream().map(Present::toSimpleDataResponse).collect(Collectors.toList()))
+            .build();
+  }
+
+  public SimpleDataResponse toSimpleDataResponse() {
+
+    return SimpleDataResponse.builder()
+            .id(id.toString())
+            .build();
+  }
 
 }

--- a/src/main/java/com/zipup/server/user/dto/UserListResponse.java
+++ b/src/main/java/com/zipup/server/user/dto/UserListResponse.java
@@ -1,0 +1,16 @@
+package com.zipup.server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserListResponse {
+  private String id;
+  private String name;
+  private String email;
+}

--- a/src/main/java/com/zipup/server/user/presentation/UserController.java
+++ b/src/main/java/com/zipup/server/user/presentation/UserController.java
@@ -1,13 +1,9 @@
 package com.zipup.server.user.presentation;
 
-import com.zipup.server.funding.dto.FundingDetailResponse;
 import com.zipup.server.user.application.UserService;
-import com.zipup.server.user.dto.SignInRequest;
-import com.zipup.server.user.dto.SignInResponse;
-import com.zipup.server.user.dto.SignUpRequest;
-import com.zipup.server.user.dto.TokenResponse;
+import com.zipup.server.user.domain.User;
+import com.zipup.server.user.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/user")
@@ -59,6 +56,13 @@ public class UserController {
   public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody SignInRequest request) {
     HttpHeaders headers = userService.signIn(request);
     return ResponseEntity.ok().headers(headers).build();
+  }
+
+  @Operation(summary = "임시 데이터", description = "임시")
+  @GetMapping("/temp")
+  public ResponseEntity<List<UserListResponse>> getUserList() {
+    List<UserListResponse> response = userService.getUserList();
+    return ResponseEntity.ok(response);
   }
 
 }


### PR DESCRIPTION
## 💡 구현할 기능 설명
- 전체 회원, 펀딩 주최, 결제 내역, 펀딩 참여 내역 조회용 API
- UUID 확인이 어려워 만든 임시 PR!