### PR TITLE
[fix] #19 펀딩 상세 조회 status 값 변경

### DIFF
--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -91,7 +91,7 @@ public class Fund extends BaseTimeEntity {
             .id(id.toString())
             .title(title)
             .imageUrl(imageUrl)
-            .status(duration > 0 ? "D-" + duration : "완료")
+            .status(duration > 0 ? String.valueOf(duration) : "완료")
             .percent((int) (((double) nowPresent / goalPrice) * 100))
             .organizer(user.getId().toString())
             .build();
@@ -108,7 +108,7 @@ public class Fund extends BaseTimeEntity {
             .title(title)
             .imageUrl(imageUrl)
             .description(description)
-            .status(duration > 0 ? "D-" + duration : "완료")
+            .status(duration > 0 ? String.valueOf(duration) : "완료")
             .goalPrice(goalPrice)
             .percent(nowPresent / goalPrice)
             .presentList(presents.stream().map(Present::toSummaryResponse).collect(Collectors.toList()))

--- a/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
+++ b/src/main/java/com/zipup/server/funding/dto/FundingDetailResponse.java
@@ -14,7 +14,7 @@ public class FundingDetailResponse {
   private String title;
   private String description;
   private String imageUrl;
-  @Schema(description = "펀딩 상태 ex) 완료, D-1 ...")
+  @Schema(description = "펀딩 상태 ex) 완료, 1 ...")
   private String status;
   @Schema(description = "현재 달성률")
   private Integer percent;


### PR DESCRIPTION
## 💡 구현 기능 설명
- 펀딩 상세 조회 페이지 status 값에서 'D-' 삭제