### PR TITLE
[hotfix] #5 access token httponly 제거

### DIFF
--- a/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/zipup/server/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -80,12 +80,12 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     if ((accessTokenList != null ? accessTokenList.size() : 0) > 0) {
       String accessToken = userService.resolveToken(accessTokenList.get(0));
-      CookieUtil.addResponseCookie(response, HttpHeaders.AUTHORIZATION, accessToken, COOKIE_EXPIRE_SECONDS, client);
+      CookieUtil.addResponseAccessCookie(response, HttpHeaders.AUTHORIZATION, accessToken, COOKIE_EXPIRE_SECONDS, client);
     }
 
     if ((refreshTokenList != null ? refreshTokenList.size() : 0) > 0) {
       String refreshToken = userService.resolveToken(refreshTokenList.get(0));
-      CookieUtil.addResponseCookie(response, COOKIE_TOKEN_REFRESH, refreshToken, COOKIE_EXPIRE_SECONDS, client);
+      CookieUtil.addResponseSecureCookie(response, COOKIE_TOKEN_REFRESH, refreshToken, COOKIE_EXPIRE_SECONDS, client);
     }
 
     return UriComponentsBuilder.fromUriString(targetUrl)

--- a/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -47,11 +47,12 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
       return;
     }
 
+    CookieUtil.addCookie(response, HttpHeaders.AUTHORIZATION, CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
     CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
     String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
 
-    if (StringUtils.isNotBlank(redirectUriAfterLogin))
-      CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
+//    if (StringUtils.isNotBlank(redirectUriAfterLogin))
+//      CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
   }
 
   @Override

--- a/src/main/java/com/zipup/server/global/security/util/CookieUtil.java
+++ b/src/main/java/com/zipup/server/global/security/util/CookieUtil.java
@@ -34,13 +34,23 @@ public class CookieUtil {
   public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
     Cookie cookie = new Cookie(name, value);
     cookie.setPath("/");
-    cookie.setHttpOnly(true);
+//    cookie.setHttpOnly(true);
     cookie.setMaxAge(maxAge);
 
     response.addCookie(cookie);
   }
 
-  public static ResponseCookie addResponseCookie(String name, String value, int maxAge) {
+  public static ResponseCookie addResponseAccessCookie(String name, String value, int maxAge) {
+    return ResponseCookie.from(name, value)
+            .maxAge(maxAge)
+            .sameSite("None")
+//            .secure(true)
+//            .httpOnly(true)
+            .path("/")
+            .build();
+  }
+
+  public static ResponseCookie addResponseSecureCookie(String name, String value, int maxAge) {
     return ResponseCookie.from(name, value)
             .maxAge(maxAge)
             .sameSite("None")
@@ -50,7 +60,24 @@ public class CookieUtil {
             .build();
   }
 
-  public static ResponseCookie addResponseCookie(HttpServletResponse response, String name, String value, int maxAge, String url) {
+  public static ResponseCookie addResponseAccessCookie(HttpServletResponse response, String name, String value, int maxAge, String url) {
+    String domain = extractDomain(url);
+
+    ResponseCookie cookie = ResponseCookie.from(name, value)
+            .maxAge(maxAge)
+            .sameSite("None")
+//            .secure(true)
+//            .httpOnly(true)
+            .path("/")
+            .domain(domain)
+            .build();
+
+    response.addHeader(SET_COOKIE, cookie.toString());
+
+    return cookie;
+  }
+
+  public static ResponseCookie addResponseSecureCookie(HttpServletResponse response, String name, String value, int maxAge, String url) {
     String domain = extractDomain(url);
 
     ResponseCookie cookie = ResponseCookie.from(name, value)

--- a/src/main/java/com/zipup/server/user/application/AuthService.java
+++ b/src/main/java/com/zipup/server/user/application/AuthService.java
@@ -44,8 +44,8 @@ public class AuthService {
     );
 
     return new ResponseCookie[] {
-            CookieUtil.addResponseCookie(HttpHeaders.AUTHORIZATION, newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
-            CookieUtil.addResponseCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS)
+            CookieUtil.addResponseAccessCookie(HttpHeaders.AUTHORIZATION, newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
+            CookieUtil.addResponseSecureCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS)
     };
   }
 


### PR DESCRIPTION
## 💡 구현 기능 설명
- access token 리턴 시 httponly 제거