### PR TITLE
[fix] #19 user-id 없을 때 분기 처리 수정

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -9,6 +9,8 @@ import com.zipup.server.funding.infrastructure.FundRepository;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.user.application.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,10 +62,11 @@ public class FundService {
             .collect(Collectors.toList());
   }
 
-  public FundingDetailResponse getFundingDetail(String fundId, String userId) {
+  public FundingDetailResponse getFundingDetail(String fundId) {
     isValidUUID(fundId);
-    if (!userId.isEmpty()) isValidUUID(userId);
-    return findById(fundId).toDetailResponse(userId);
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    return findById(fundId).toDetailResponse(authentication.getName());
   }
 
   public List<FundingSummaryResponse> getFundList() {

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -101,7 +101,7 @@ public class Fund extends BaseTimeEntity {
     int nowPresent = presents.stream()
             .mapToInt(present -> present.getPayment().getPrice())
             .sum();
-    Boolean isOrganizer = nowUserId.equals(user.getId().toString());
+    Boolean isOrganizer = nowUserId == null ? false : nowUserId.equals(user.getId().toString());
     boolean isParticipant = presents.stream()
             .anyMatch(p -> p.getUser().getId().toString().equals(nowUserId));
 

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -67,9 +67,9 @@ public class FundController {
   @GetMapping("")
   public ResponseEntity<FundingDetailResponse> getFundingDetail(
           @RequestParam(value = "funding") String fundId,
-          @RequestParam(value = "user") String userId
+          @RequestParam(value = "user", required = false) String userId
   ) {
-    return ResponseEntity.ok(fundService.getFundingDetail(fundId, userId));
+    return ResponseEntity.ok(fundService.getFundingDetail(fundId));
   }
 
   @Operation(summary = "펀딩 주최", description = "펀딩 주최")


### PR DESCRIPTION
## 💡 구현 기능 설명
- user-id 인자에 안 받으면 비회원으로 확인하도록 구현
- accesstoken에서 user 인가 가능하게 수정