### PR TITLE
[fix] #13 펀딩 개설 시 jwt로 인가 처리

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -45,9 +45,10 @@ public class FundService {
 
   @Transactional
   public SimpleDataResponse createFunding(CreateFundingRequest request) {
-    Fund targetFund = request.toEntity();
-    targetFund.setUser(userService.findById(request.getUser()));
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+    Fund targetFund = request.toEntity();
+    targetFund.setUser(userService.findById(authentication.getName()));
     Fund response = fundRepository.save(targetFund);
 
     return new SimpleDataResponse(response.getId().toString());

--- a/src/main/java/com/zipup/server/funding/dto/CreateFundingRequest.java
+++ b/src/main/java/com/zipup/server/funding/dto/CreateFundingRequest.java
@@ -35,8 +35,6 @@ public class CreateFundingRequest {
   private String fundingStart;
   @Schema(description = "펀딩 종료")
   private String fundingFinish;
-  @Schema(description = "주최자 \'식별자\' (UUID) ")
-  private String user;
 
   public Fund toEntity() {
     return Fund.builder()

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -79,16 +79,8 @@ public class FundController {
           description = "펀딩 주최 성공",
           content = @Content(schema = @Schema(implementation = CreateFundingRequest.class)))
   @PostMapping("")
-  public ResponseEntity<CreateFundingRequest> createFunding(@RequestPart("request") CreateFundingRequest request
-  ) {
-    SimpleDataResponse response = fundService.createFunding(request);
-
-    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-            .path("/{id}")
-            .buildAndExpand(response.getId())
-            .toUri();
-
-    return ResponseEntity.created(location).build();
+  public ResponseEntity<SimpleDataResponse> createFunding(@RequestBody CreateFundingRequest request) {
+    return ResponseEntity.ok(fundService.createFunding(request));
   }
 
   @Operation(summary = "임시 데이터", description = "임시")


### PR DESCRIPTION
## 💡 구현 기능 설명
- 펀딩 개설 시 인자에 user id 받지 않고 그냥 헤더 토큰으로 인가 처리
- 요청 객체를 requestpart -> requestbody로 수정