### PR TITLE
[fix] #13 펀딩 개설 시 아예 식별자로 인증처리 부분 삭제

### DIFF
--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -73,7 +73,6 @@ public class FundController {
   }
 
   @Operation(summary = "펀딩 주최", description = "펀딩 주최")
-  @Parameter(name = "funding", description = "선택한 펀딩의 식별자 값 (UUID)")
   @ApiResponse(
           responseCode = "201",
           description = "펀딩 주최 성공",


### PR DESCRIPTION
## 💡 구현 기능 설명
- 펀딩 개설 시 아예 식별자로 인증처리 부분 삭제
