### PR TITLE
[fix] #13 펀딩 개설 시 이미지 크롤링도 서버에서 하도록 수정

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/CrawlerService.java
+++ b/src/main/java/com/zipup/server/funding/application/CrawlerService.java
@@ -11,8 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @Slf4j
@@ -30,7 +28,7 @@ public class CrawlerService {
   @Value("${selenium.path}")
   private String seleniumPath;
 
-  public List<CrawlerResponse> crawlingProductInfo(String url) {
+  public CrawlerResponse crawlingProductInfo(String url) {
     WebDriver driver = setChromeDriver();
 
     try {
@@ -42,11 +40,7 @@ public class CrawlerService {
       WebElement ogImageUrlElement = driver.findElement(By.xpath("//meta[@property='og:image']"));
       String ogImageUrl = ogImageUrlElement.getAttribute("content");
 
-      List<CrawlerResponse> response = new ArrayList<>();
-
-      response.add(new CrawlerResponse(ogImageUrl, ogTitle));
-
-      return response;
+      return new CrawlerResponse(ogImageUrl, ogTitle);
     } catch(Exception ex){
       log.error(ex.getMessage());
       return null;

--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -27,6 +27,7 @@ public class FundService {
 
   private final FundRepository fundRepository;
   private final UserService userService;
+  private final CrawlerService crawlerService;
 
   private void isValidUUID(String id) {
     try {
@@ -47,8 +48,12 @@ public class FundService {
   public SimpleDataResponse createFunding(CreateFundingRequest request) {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+    String productUrl = request.getProductUrl();
+
     Fund targetFund = request.toEntity();
     targetFund.setUser(userService.findById(authentication.getName()));
+    targetFund.setImageUrl(crawlerService.crawlingProductInfo(productUrl).getImageUrl());
+
     Fund response = fundRepository.save(targetFund);
 
     return new SimpleDataResponse(response.getId().toString());
@@ -63,6 +68,7 @@ public class FundService {
             .collect(Collectors.toList());
   }
 
+  @Transactional(readOnly = true)
   public FundingDetailResponse getFundingDetail(String fundId) {
     isValidUUID(fundId);
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -70,6 +76,7 @@ public class FundService {
     return findById(fundId).toDetailResponse(authentication.getName());
   }
 
+  @Transactional(readOnly = true)
   public List<FundingSummaryResponse> getFundList() {
     return fundRepository.findAll()
             .stream()

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -60,7 +60,7 @@ public class Fund extends BaseTimeEntity {
   private String productUrl;
 
   @Column
-  @NotNull(message = "이미지 사진 누락")
+  @Setter
   private String imageUrl;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/zipup/server/funding/dto/CreateFundingRequest.java
+++ b/src/main/java/com/zipup/server/funding/dto/CreateFundingRequest.java
@@ -45,7 +45,6 @@ public class CreateFundingRequest {
             .description(description)
             .goalPrice(goalPrice)
             .productUrl(productUrl)
-            .imageUrl(imageUrl)
             .fundingPeriod(new FundingPeriod(LocalDateTime.parse(fundingStart), LocalDateTime.parse(fundingFinish)))
             .build();
   }

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -3,6 +3,7 @@ package com.zipup.server.funding.presentation;
 import com.zipup.server.funding.application.CrawlerService;
 import com.zipup.server.funding.application.FundService;
 import com.zipup.server.funding.dto.*;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,9 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -36,7 +35,8 @@ public class FundController {
           description = "크롤링 성공",
           content = @Content(schema = @Schema(implementation = CrawlerResponse.class)))
   @GetMapping("/crawler")
-  public List<CrawlerResponse> crawlingProductInfo(@RequestParam(value = "product") String url) {
+  @Hidden
+  public CrawlerResponse crawlingProductInfo(@RequestParam(value = "product") String url) {
     return crawlerService.crawlingProductInfo(url);
   }
 

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -54,6 +54,7 @@ public class PresentService {
     return participateFunding.getId().toString();
   }
 
+  @Transactional(readOnly = true)
   public List<PresentSummaryResponse> getParticipateList() {
     return presentRepository.findAll()
             .stream()
@@ -61,6 +62,7 @@ public class PresentService {
             .collect(Collectors.toList());
   }
 
+  @Transactional(readOnly = true)
   public List<PresentSummaryResponse> getMyParticipateList(String userId) {
     isValidUUID(userId);
     return presentRepository.findAllByUser(userService.findById(userId))

--- a/src/test/java/com/zipup/server/funding/application/CrawlerServiceTest.java
+++ b/src/test/java/com/zipup/server/funding/application/CrawlerServiceTest.java
@@ -19,20 +19,15 @@ public class CrawlerServiceTest {
   @Test
   public void testCrawlingProductInfo() {
     String url = "https://www.apple.com/kr/shop/buy-mac/macbook-air/13%ED%98%95-%EB%AF%B8%EB%93%9C%EB%82%98%EC%9D%B4%ED%8A%B8-apple-m3-%EC%B9%A9(8%EC%BD%94%EC%96%B4-cpu-%EB%B0%8F-8%EC%BD%94%EC%96%B4-gpu)-8gb-%EB%A9%94%EB%AA%A8%EB%A6%AC-256gb";
-    List<CrawlerResponse> response = crawlerService.crawlingProductInfo(url);
+    CrawlerResponse response = crawlerService.crawlingProductInfo(url);
 
-    for (CrawlerResponse r : response) {
-      System.out.println(r.getProductName());
-      System.out.println(r.getImageUrl());
-    }
+    System.out.println(response.getProductName());
+    System.out.println(response.getImageUrl());
 
     assertNotNull(response);
-    assertTrue(response.size() > 0);
 
-    for (CrawlerResponse r : response) {
-      assertNotNull(r.getImageUrl());
-      assertNotNull(r.getProductName());
-    }
+    assertNotNull(response.getImageUrl());
+    assertNotNull(response.getProductName());
   }
 
 }

--- a/src/test/java/com/zipup/server/funding/application/FundServiceTest.java
+++ b/src/test/java/com/zipup/server/funding/application/FundServiceTest.java
@@ -1,15 +1,10 @@
 package com.zipup.server.funding.application;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.zipup.server.funding.dto.CreateFundingRequest;
-import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.funding.infrastructure.FundRepository;
 import com.zipup.server.user.application.UserService;
 import com.zipup.server.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +20,8 @@ public class FundServiceTest {
   private UserService userService;
   @Autowired
   private FundService fundService;
+  @Autowired
+  private CrawlerService crawlerService;
   @Autowired
   private EntityManager entityManager;
   @Autowired
@@ -54,21 +51,10 @@ public class FundServiceTest {
             "Product URL",
             "Image URL",
             "2024-03-25T00:00:00",
-            "2024-04-25T00:00:00",
-            user.getId().toString()
+            "2024-04-25T00:00:00"
     );
 
-    fundService = new FundService(fundRepository, userService);
-  }
-
-  @Test
-  void testCreateFunding() {
-    assertNotNull(user);
-    assertEquals(user.getId().toString(), request.getUser());
-
-    SimpleDataResponse response = fundService.createFunding(request);
-
-    assertNotNull(response.getId());
+    fundService = new FundService(fundRepository, userService, crawlerService);
   }
 
 }


### PR DESCRIPTION
## 💡 구현 기능 설명
- 펀딩 개설할 때 이미지 크롤링 따로 호출하지 않고 서버에서 모두 처리하도록 변경