### PR TITLE
[hotfix] #97 토큰 리프레시 로직에서 request 객체에서 쿠키 빼내도록 수정

### DIFF
--- a/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
@@ -44,10 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             : cookieAttribute.get(HttpHeaders.AUTHORIZATION) != null ? cookieAttribute.get(HttpHeaders.AUTHORIZATION)
             : null;
 
-    if (!StringUtils.hasText(accessToken)) {
-      log.error("has no text :: {} {} {}", NOT_EXIST_TOKEN.getMessage(), StringUtils.hasText(accessToken), requestURI);
-      request.setAttribute("exception", NOT_EXIST_TOKEN);
-    }
+    if (!StringUtils.hasText(accessToken)) request.setAttribute("exception", NOT_EXIST_TOKEN);
 
     else if (StringUtils.hasText(accessToken)) {
       try{

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.zipup.server.user.presentation;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.user.application.AuthService;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -21,8 +22,11 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 import static com.zipup.server.global.exception.CustomErrorCode.TOKEN_NOT_FOUND;
 import static com.zipup.server.global.security.util.CookieUtil.COOKIE_TOKEN_REFRESH;
+import static com.zipup.server.global.security.util.CookieUtil.getCookie;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @RestController
@@ -75,9 +79,13 @@ public class AuthController {
     })
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
-            @CookieValue(COOKIE_TOKEN_REFRESH) final String refreshToken,
+            final HttpServletRequest httpServletRequest,
             final HttpServletResponse httpServletResponse
     ) {
+        Optional<Cookie> refreshTokenCookie = getCookie(httpServletRequest, COOKIE_TOKEN_REFRESH);
+        if (refreshTokenCookie.isEmpty()) throw new BaseException(TOKEN_NOT_FOUND);
+
+        String refreshToken = refreshTokenCookie.get().getValue();
         if (refreshToken == null) throw new BaseException(TOKEN_NOT_FOUND);
 
         ResponseCookie[] newToken = authService.refresh(refreshToken);

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -75,10 +75,9 @@ public class AuthController {
     })
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
-            final HttpServletRequest httpServletRequest,
+            @CookieValue(COOKIE_TOKEN_REFRESH) final String refreshToken,
             final HttpServletResponse httpServletResponse
     ) {
-        String refreshToken = httpServletRequest.getHeader(COOKIE_TOKEN_REFRESH);
         if (refreshToken == null) throw new BaseException(TOKEN_NOT_FOUND);
 
         ResponseCookie[] newToken = authService.refresh(refreshToken);

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -1,5 +1,6 @@
 package com.zipup.server.user.presentation;
 
+import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.user.application.AuthService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.zipup.server.global.exception.CustomErrorCode.TOKEN_NOT_FOUND;
 import static com.zipup.server.global.security.util.CookieUtil.COOKIE_TOKEN_REFRESH;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
@@ -73,9 +75,12 @@ public class AuthController {
     })
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
-            @CookieValue(COOKIE_TOKEN_REFRESH) final String refreshToken,
+            final HttpServletRequest httpServletRequest,
             final HttpServletResponse httpServletResponse
     ) {
+        String refreshToken = httpServletRequest.getHeader(COOKIE_TOKEN_REFRESH);
+        if (refreshToken == null) throw new BaseException(TOKEN_NOT_FOUND);
+
         ResponseCookie[] newToken = authService.refresh(refreshToken);
         httpServletResponse.addHeader(SET_COOKIE, newToken[0].toString());
         httpServletResponse.addHeader(SET_COOKIE, newToken[1].toString());


### PR DESCRIPTION
## 💡 구현 기능 설명
- AuthController 에서 request 객체에서 쿠키 빼내도록 수정
