### PR TITLE
[hotfix] #97 토큰 리프레시 테스트 시 accesstoken 용 쿠키 추가

### DIFF
--- a/src/main/java/com/zipup/server/user/application/AuthService.java
+++ b/src/main/java/com/zipup/server/user/application/AuthService.java
@@ -77,7 +77,8 @@ public class AuthService {
 
     return new ResponseCookie[] {
             CookieUtil.addResponseAccessCookie(HttpHeaders.AUTHORIZATION, newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
-            CookieUtil.addResponseSecureCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS)
+            CookieUtil.addResponseSecureCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS),
+            CookieUtil.addResponseAccessCookie("access-token", newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS)
     };
   }
 

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -91,6 +91,7 @@ public class AuthController {
         ResponseCookie[] newToken = authService.refresh(refreshToken);
         httpServletResponse.addHeader(SET_COOKIE, newToken[0].toString());
         httpServletResponse.addHeader(SET_COOKIE, newToken[1].toString());
+        httpServletResponse.addHeader(SET_COOKIE, newToken[2].toString());
 
         return ResponseEntity.ok().body(new TokenResponse(newToken[0].getValue()));
     }


### PR DESCRIPTION
## 💡 구현 기능 설명
- 토큰 리프레시 테스트 시 accesstoken 용 쿠키 추가