### PR TITLE
[hotfix] #94 참여 펀딩 목록 조회 시 펀딩 정보 응답하도록 변경

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -85,4 +85,5 @@ public class FundService {
             .map(Fund::toSummaryResponse)
             .collect(Collectors.toList());
   }
+
 }

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -1,6 +1,7 @@
 package com.zipup.server.present.application;
 
 import com.zipup.server.funding.application.FundService;
+import com.zipup.server.funding.dto.FundingSummaryResponse;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.payment.application.PaymentService;
 import com.zipup.server.present.domain.Present;
@@ -63,11 +64,12 @@ public class PresentService {
   }
 
   @Transactional(readOnly = true)
-  public List<PresentSummaryResponse> getMyParticipateList(String userId) {
+  public List<FundingSummaryResponse> getMyParticipateList(String userId) {
     isValidUUID(userId);
     return presentRepository.findAllByUser(userService.findById(userId))
             .stream()
-            .map(Present::toSummaryResponse)
+            .map(present -> present.getFund().toSummaryResponse())
             .collect(Collectors.toList());
   }
+
 }

--- a/src/main/java/com/zipup/server/present/presentation/PresentController.java
+++ b/src/main/java/com/zipup/server/present/presentation/PresentController.java
@@ -1,5 +1,6 @@
 package com.zipup.server.present.presentation;
 
+import com.zipup.server.funding.dto.FundingSummaryResponse;
 import com.zipup.server.present.application.PresentService;
 import com.zipup.server.present.dto.ParticipatePresentRequest;
 import com.zipup.server.present.dto.PresentSummaryResponse;
@@ -47,9 +48,9 @@ public class PresentController {
   @ApiResponse(
           responseCode = "200",
           description = "조회 성공",
-          content = @Content(schema = @Schema(implementation = PresentSummaryResponse.class)))
+          content = @Content(schema = @Schema(implementation = FundingSummaryResponse.class)))
   @GetMapping("/list")
-  public ResponseEntity<List<PresentSummaryResponse>> getMyParticipateList(@RequestParam(value = "user") String userId) {
+  public ResponseEntity<List<FundingSummaryResponse>> getMyParticipateList(@RequestParam(value = "user") String userId) {
     return ResponseEntity.ok(presentService.getMyParticipateList(userId));
   }
 


### PR DESCRIPTION
## 💡 구현 기능 설명
- 기존 응답하는 객체가 '참여' 엔티티였는데, 이를 '펀딩' 엔티티로 응답하도록 수정 구현
