### PR TITLE
[fix] #97 refresh 요청 시 access token은 쿠키에서 제거

### DIFF
--- a/src/main/java/com/zipup/server/user/application/AuthService.java
+++ b/src/main/java/com/zipup/server/user/application/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
     );
 
     return new ResponseCookie[] {
-            CookieUtil.addResponseAccessCookie("access-token", newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
+            CookieUtil.addResponseAccessCookie(HttpHeaders.AUTHORIZATION, newToken.getAccessToken(), COOKIE_EXPIRE_SECONDS),
             CookieUtil.addResponseSecureCookie(COOKIE_TOKEN_REFRESH, newToken.getRefreshToken(), COOKIE_EXPIRE_SECONDS)
     };
   }

--- a/src/main/java/com/zipup/server/user/presentation/AuthController.java
+++ b/src/main/java/com/zipup/server/user/presentation/AuthController.java
@@ -55,7 +55,6 @@ public class AuthController {
         String redirectUrl = httpServletRequest.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
         TokenAndUserInfoResponse response = authService.signInWithAccessToken(httpServletRequest);
 
-        httpServletResponse.addHeader(SET_COOKIE, response.getAccessToken().toString());
         httpServletResponse.addHeader(SET_COOKIE, response.getRefreshToken().toString());
 
         String newAccessToken = response.getAccessToken().getValue();
@@ -89,7 +88,6 @@ public class AuthController {
         if (refreshToken == null) throw new BaseException(TOKEN_NOT_FOUND);
 
         ResponseCookie[] newToken = authService.refresh(refreshToken);
-        httpServletResponse.addHeader(SET_COOKIE, newToken[0].toString());
         httpServletResponse.addHeader(SET_COOKIE, newToken[1].toString());
 
         return ResponseEntity.ok().body(new TokenResponse(newToken[0].getValue()));


### PR DESCRIPTION
## 💡 구현 기능 설명
- `/auth/~` 요청 시 access token은 header에, refresh token은 쿠키에 담아 리턴
