### PR TITLE
[fix] #107 uuid 예외도 객체로 응답하도록 구현

### DIFF
--- a/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
@@ -89,4 +89,11 @@ public class GlobalExceptionHandler {
             .body(new ErrorResponse(ex.getStatus(), ex.getMessage(), ex.getCode()));
   }
 
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(UUIDException.class)
+  public ErrorResponse handleUUIDException(UUIDException ex) {
+    log.error("--- UUIDException ---", ex);
+    return ErrorResponse.toErrorResponse(ex.getStatus());
+  }
+
 }

--- a/src/main/java/com/zipup/server/global/exception/UUIDException.java
+++ b/src/main/java/com/zipup/server/global/exception/UUIDException.java
@@ -1,0 +1,18 @@
+package com.zipup.server.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class UUIDException extends RuntimeException {
+
+  private final CustomErrorCode status;
+
+  public UUIDException(CustomErrorCode status) {
+    this.status = status;
+  }
+
+}
+

--- a/src/main/java/com/zipup/server/global/util/UUIDUtil.java
+++ b/src/main/java/com/zipup/server/global/util/UUIDUtil.java
@@ -1,5 +1,7 @@
 package com.zipup.server.global.util;
 
+import com.zipup.server.global.exception.UUIDException;
+
 import java.util.UUID;
 
 import static com.zipup.server.global.exception.CustomErrorCode.INVALID_USER_UUID;
@@ -9,7 +11,7 @@ public class UUIDUtil {
     try {
       UUID.fromString(id);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(INVALID_USER_UUID.getMessage() + id);
+      throw new UUIDException(INVALID_USER_UUID);
     }
   }
 }


### PR DESCRIPTION
## 💡 구현 기능 설명
- 기존 문자열로 응답하던 uuid 예외 처리를 객체 형식으로 변환해서 응답 