### PR TITLE
[feat] #109 결제 취소 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -83,7 +83,7 @@ public class Fund extends BaseTimeEntity {
   public FundingSummaryResponse toSummaryResponse() {
     long duration = Duration.between(LocalDateTime.now(), fundingPeriod.getFinishFunding()).toDays();
     int nowPresent = presents.stream()
-            .mapToInt(present -> present.getPayment().getPrice())
+            .mapToInt(present -> present.getPayment().getBalanceAmount())
             .sum();
 
     int percentage = (int) Math.round(((double) nowPresent / goalPrice) * 100);
@@ -104,7 +104,7 @@ public class Fund extends BaseTimeEntity {
   public FundingDetailResponse toDetailResponse(String nowUserId) {
     long duration = Duration.between(LocalDateTime.now(), fundingPeriod.getFinishFunding()).toDays();
     int nowPresent = presents.stream()
-            .mapToInt(present -> present.getPayment().getPrice())
+            .mapToInt(present -> present.getPayment().getBalanceAmount())
             .sum();
     Boolean isOrganizer = nowUserId != null && nowUserId.equals(user.getId().toString());
     boolean isParticipant = presents.stream()

--- a/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
@@ -22,6 +22,7 @@ public enum CustomErrorCode {
    */
   INVALID_USER_UUID(3001, "유효하지 않은 UUID 입니다. :: "),
   DATA_NOT_FOUND(3002, "존재하지 않는 데이터에요."),
+  UNIQUE_CONSTRAINT(3003, "Unique 키가 충돌해요"),
 
   /**
    * 4000 : 연결 오류

--- a/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
@@ -18,10 +18,10 @@ public enum CustomErrorCode {
   ACCESS_DENIED(2007, "권한이 없습니다."),
 
   /**
-   * 4000 : 비즈니스 오류
+   * 3000 : 비즈니스 오류
    */
-  INVALID_USER_UUID(2101, "유효하지 않은 UUID 입니다. :: "),
-  DATA_NOT_FOUND(2102, "존재하지 않는 데이터에요."),
+  INVALID_USER_UUID(3001, "유효하지 않은 UUID 입니다. :: "),
+  DATA_NOT_FOUND(3002, "존재하지 않는 데이터에요."),
 
   /**
    * 4000 : 연결 오류

--- a/src/main/java/com/zipup/server/global/exception/ErrorResponse.java
+++ b/src/main/java/com/zipup/server/global/exception/ErrorResponse.java
@@ -1,7 +1,10 @@
 package com.zipup.server.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode
@@ -14,6 +17,14 @@ public class ErrorResponse {
     this.code = code;
     this.message = message;
     this.error_name = name;
+  }
+
+  @JsonCreator
+  public ErrorResponse(@JsonProperty("code") String code,
+                       @JsonProperty("message") String message) {
+    this.code = 0;
+    this.message = message;
+    this.error_name = code;
   }
 
   public static ErrorResponse toErrorResponse(CustomErrorCode errorCode) {

--- a/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipup/server/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,8 @@ import javax.persistence.NoResultException;
 import javax.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 
+import static com.zipup.server.global.exception.CustomErrorCode.UNIQUE_CONSTRAINT;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -94,6 +96,13 @@ public class GlobalExceptionHandler {
   public ErrorResponse handleUUIDException(UUIDException ex) {
     log.error("--- UUIDException ---", ex);
     return new ErrorResponse(ex.getStatus().getCode(), ex.getMessage(), ex.getStatus().name());
+  }
+
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler(UniqueConstraintException.class)
+  public ErrorResponse handleUniqueConstraintException(UniqueConstraintException ex) {
+    log.error("--- ResourceNotFoundException ---", ex);
+    return new ErrorResponse(UNIQUE_CONSTRAINT.getCode().intValue(), ex.getMessage(), "UNIQUE_CONSTRAINT");
   }
 
 }

--- a/src/main/java/com/zipup/server/global/exception/UniqueConstraintException.java
+++ b/src/main/java/com/zipup/server/global/exception/UniqueConstraintException.java
@@ -1,0 +1,18 @@
+package com.zipup.server.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.CONFLICT)
+public class UniqueConstraintException extends RuntimeException {
+  private String key;
+  private String value;
+
+  public UniqueConstraintException(String key, String value) {
+    super(key + " 키에 대한 " + value + " 값이 이미 존재해요.");
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/src/main/java/com/zipup/server/global/util/entity/BaseTimeEntity.java
+++ b/src/main/java/com/zipup/server/global/util/entity/BaseTimeEntity.java
@@ -3,6 +3,7 @@ package com.zipup.server.global.util.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -14,6 +15,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @SuperBuilder
@@ -33,5 +35,5 @@ public abstract class BaseTimeEntity {
 
   @Enumerated(EnumType.STRING)
   @Column(columnDefinition = "ENUM('PRIVATE', 'PUBLIC') DEFAULT 'PUBLIC'")
-  private ColumnStatus status;
+  private ColumnStatus status = ColumnStatus.PUBLIC;
 }

--- a/src/main/java/com/zipup/server/global/util/entity/PaymentStatus.java
+++ b/src/main/java/com/zipup/server/global/util/entity/PaymentStatus.java
@@ -1,0 +1,24 @@
+package com.zipup.server.global.util.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus implements BaseEnumCode<String> {
+  READY("결제를 생성하면 가지게 되는 초기 상태"),
+  IN_PROGRESS("결제수단 정보와 해당 결제수단의 소유자가 맞는지 인증을 마친 상태. 30분 안에 결제 승인 API를 호출하면 결제 완료."),
+  EXPIRED("결제 유효 시간 30분이 지나 거래가 취소된 상태."),
+  WAITING_FOR_DEPOSIT("결제 고객이 발급된 가상계좌에 입금하는 것을 기다리고 있는 상태."),
+  DONE("요청한 결제가 승인된 상태."),
+  CANCELED("승인된 결제가 취소된 상태."),
+  PARTIAL_CANCELED("승인된 결제가 부분 취소된 상태."),
+  ABORTED("결제 승인이 실패한 상태.");
+
+  private final String value;
+
+  @Override
+  public String getValue() {
+    return this.value;
+  }
+}

--- a/src/main/java/com/zipup/server/global/util/entity/RefundStatus.java
+++ b/src/main/java/com/zipup/server/global/util/entity/RefundStatus.java
@@ -1,0 +1,21 @@
+package com.zipup.server.global.util.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RefundStatus implements BaseEnumCode<String> {
+  NONE("환불 요청이 없는 상태."),
+  PENDING("환불을 처리 중인 상태."),
+  FAILED("환불에 실패한 상태."),
+  PARTIAL_FAILED("부분 환불에 실패한 상태."),
+  COMPLETED("환불이 완료된 상태.");
+
+  private final String value;
+
+  @Override
+  public String getValue() {
+    return this.value;
+  }
+}

--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -1,8 +1,8 @@
 package com.zipup.server.payment.application;
 
 import com.zipup.server.global.exception.BaseException;
-import com.zipup.server.global.exception.PaymentException;
 import com.zipup.server.global.exception.ResourceNotFoundException;
+import com.zipup.server.global.exception.UniqueConstraintException;
 import com.zipup.server.payment.domain.Payment;
 import com.zipup.server.payment.dto.PaymentCancelRequest;
 import com.zipup.server.payment.dto.PaymentConfirmRequest;
@@ -11,39 +11,27 @@ import com.zipup.server.payment.dto.TossPaymentResponse;
 import com.zipup.server.payment.infrastructure.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.zipup.server.global.exception.CustomErrorCode.ACCESS_DENIED;
-import static com.zipup.server.global.exception.CustomErrorCode.DATA_NOT_FOUND;
+import static com.zipup.server.global.exception.CustomErrorCode.*;
 import static com.zipup.server.global.util.UUIDUtil.isValidUUID;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static com.zipup.server.global.util.entity.PaymentStatus.CANCELED;
+import static com.zipup.server.global.util.entity.PaymentStatus.PARTIAL_CANCELED;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
-
-  @Value("${toss.widget.secretKey}")
-  private String SECRET_KEY;
-  @Value("${toss.widget.api.payments}")
-  private String TOSS_PAYMENTS_API;
 
   private final TossService tossService;
   private final RedisTemplate<String, String> redisTemplate;
@@ -56,111 +44,95 @@ public class PaymentService {
             .orElseThrow(() -> new ResourceNotFoundException(DATA_NOT_FOUND));
   }
 
-  public Boolean isOrderIdExist(String orderId) {
-    return redisTemplate.opsForValue().get(orderId) == null;
+  @Transactional(readOnly = true)
+  public Payment findByPaymentKey(String paymentKey) {
+    return paymentRepository.findByPaymentKey(paymentKey)
+            .orElseThrow(() -> new ResourceNotFoundException(DATA_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  public Boolean existsByPaymentKey(String paymentKey) {
+    return paymentRepository.existsByPaymentKey(paymentKey);
+  }
+
+  @Transactional(readOnly = true)
+  public Boolean existsByOrderId(String orderId) {
+    return paymentRepository.existsByOrderId(orderId);
+  }
+
+  public Boolean isOrderIdExistInRedis(String orderId) {
+    return redisTemplate.opsForValue().get(orderId) != null;
   }
 
   public Boolean checkPaymentInfo(String orderId, Integer amount) {
-    if (!isOrderIdExist(orderId)) return false;
+    if (isOrderIdExistInRedis(orderId)) return false;
 
     redisTemplate.opsForValue().set(orderId, String.valueOf(amount));
     return true;
   }
 
-  public PaymentResultResponse successPayment(PaymentConfirmRequest request) throws IOException, ParseException {
-    byte[] encodedBytes = Base64.getEncoder()
-            .encode((SECRET_KEY + ":").getBytes(UTF_8));
-
-    HttpURLConnection connection = confirmPaymentToToss(encodedBytes);
-
-    OutputStream outputStream = connection.getOutputStream();
+  @Transactional
+  public PaymentResultResponse confirmPayment(PaymentConfirmRequest request) {
+    if (existsByPaymentKey(request.getPaymentKey())) throw new UniqueConstraintException("PaymentKey", request.getPaymentKey());
+    if (existsByOrderId(request.getOrderId())) throw new UniqueConstraintException("OrderId", request.getOrderId());
+    if (!isOrderIdExistInRedis(request.getOrderId())) throw new ResourceNotFoundException(DATA_NOT_FOUND);
 
     Map<String, Object> data = new HashMap<>();
     data.put("orderId", request.getOrderId());
     data.put("amount", request.getAmount());
     data.put("paymentKey", request.getPaymentKey());
-
     JSONObject obj = new JSONObject(data);
 
-    outputStream.write(obj.toString().getBytes(UTF_8));
+    Mono<TossPaymentResponse> resultResponseMono = tossService.post("/confirm", obj, TossPaymentResponse.class);
+    TossPaymentResponse response = resultResponseMono.block();
+    String method = response != null ? response.getMethod() : null;
 
-    int code = connection.getResponseCode();
-    boolean isSuccess = code == 200;
+    if (method == null)
+      throw new BaseException(UNKNOWN_ERROR);
 
-    InputStream responseStream = isSuccess ? connection.getInputStream() : connection.getErrorStream();
-
-    Reader reader = new InputStreamReader(responseStream, UTF_8);
-    JSONParser parser = new JSONParser();
-    JSONObject jsonObject = (JSONObject) parser.parse(reader);
-
-    if (!isSuccess)
-      throw new PaymentException(code, jsonObject.get("code").toString(), jsonObject.get("message").toString());
-
-    System.out.println(jsonObject);
-    String method = jsonObject.get("method").toString();
     String cardNumber = "";
     String accountNumber = "";
     String bank = "";
-    String customerMobilePhone = "";
-    String message = "";
-    String resultId = "";
+    String phoneNumber = "";
+    String easyPay = "";
 
-    if (method != null) {
-      switch (method) {
-        case "카드":
-          cardNumber = ((JSONObject) jsonObject.get("card")).get("number").toString();
-          break;
-        case "가상계좌":
-          accountNumber = ((JSONObject) jsonObject.get("virtualAccount")).get("accountNumber").toString();
-          break;
-        case "계좌이체":
-          bank = ((JSONObject) jsonObject.get("transfer")).get("bank").toString();
-          break;
-        case "휴대폰":
-          customerMobilePhone = ((JSONObject) jsonObject.get("mobilePhone")).get("customerMobilePhone").toString();
-          break;
-      }
-
-      Payment successPayment = Payment.builder()
-              .orderId(request.getOrderId())
-              .paymentKey(request.getPaymentKey())
-              .price(request.getAmount())
-              .bank(bank)
-              .paymentMethod(method)
-              .build();
-
-      resultId = paymentRepository.save(successPayment).getId().toString();
-      redisTemplate.delete(request.getOrderId());
-    } else {
-      code = Integer.parseInt(jsonObject.get("code").toString());
-      message = jsonObject.get("message").toString();
+    switch (method) {
+      case "카드":
+        cardNumber = response.getCard().getNumber();
+        break;
+      case "가상계좌":
+        bank = response.getVirtualAccount().getBankCode();
+        accountNumber = response.getVirtualAccount().getAccountNumber();
+        break;
+      case "계좌이체":
+        bank = response.getTransfer().getBankCode();
+        break;
+      case "휴대폰":
+        phoneNumber = response.getMobilePhone().getCustomerMobilePhone().getMasking();
+        break;
+      case "간편결제":
+        easyPay = response.getEasyPay().getProvider();
+        break;
     }
-    responseStream.close();
 
-    return PaymentResultResponse.builder()
-            .id(resultId)
-            .code(code)
-            .method(method)
-            .responseStr(jsonObject.toString())
+    Payment paymentResult = Payment.builder()
+            .paymentKey(response.getPaymentKey())
+            .orderId(response.getOrderId())
+            .paymentMethod(method)
+            .totalAmount(response.getTotalAmount())
+            .balanceAmount(response.getTotalAmount())
+            .paymentStatus(response.getStatus())
+            .bank(bank)
             .cardNumber(cardNumber)
             .accountNumber(accountNumber)
-            .bank(bank)
-            .customerMobilePhone(customerMobilePhone)
-            .message(message)
+            .phoneNumber(phoneNumber)
+            .easyPay(easyPay)
             .build();
-  }
 
-  public HttpURLConnection confirmPaymentToToss(byte[] encodedBytes) throws IOException {
-    String authorizations = "Basic " + new String(encodedBytes);
+    paymentRepository.save(paymentResult);
+    redisTemplate.delete(request.getOrderId());
 
-    URL url = new URL(TOSS_PAYMENTS_API + "/confirm");
-    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-    connection.setRequestProperty(AUTHORIZATION, authorizations);
-    connection.setRequestProperty(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-    connection.setRequestMethod(String.valueOf(HttpMethod.POST));
-    connection.setDoOutput(true);
-
-    return connection;
+    return paymentResult.toDetailResponse();
   }
 
   @Transactional(readOnly = true)
@@ -181,9 +153,9 @@ public class PaymentService {
     return response.block();
   }
 
-  public TossPaymentResponse cancelPayment(PaymentCancelRequest request) {
-    Payment payment = paymentRepository.findByPaymentKey(request.getPaymentKey())
-            .orElseThrow(() -> new ResourceNotFoundException(DATA_NOT_FOUND));
+  @Transactional
+  public PaymentResultResponse cancelPayment(PaymentCancelRequest request) {
+    Payment payment = findByPaymentKey(request.getPaymentKey());
     String idempotencyKey = payment.getId().toString();
 
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -191,7 +163,7 @@ public class PaymentService {
       throw new BaseException(ACCESS_DENIED);
 
     Map<String, Object> data = new HashMap<>();
-    data.put("idempotencyKey", idempotencyKey);
+    data.put("idempotencyKey", idempotencyKey+"dd");
     data.put("cancelReason", request.getCancelReason());
     if (request.getCancelAmount() != null)
       data.put("cancelAmount", request.getCancelAmount());
@@ -201,7 +173,16 @@ public class PaymentService {
 
     JSONObject obj = new JSONObject(data);
     Mono<TossPaymentResponse> response = tossService.post("/" + request.getPaymentKey() + "/cancel", obj, TossPaymentResponse.class);
-    return response.block();
+    if (request.getCancelAmount() == null || request.getCancelAmount().equals(payment.getBalanceAmount())) {
+      payment.setPaymentStatus(CANCELED);
+    } else {
+      if (request.getCancelAmount() < payment.getBalanceAmount()) {
+        payment.setBalanceAmount(payment.getBalanceAmount() - request.getCancelAmount());
+        payment.setPaymentStatus(PARTIAL_CANCELED);
+      }
+    }
+
+    return payment.toCancelResponse(response.block().getCancels());
   }
 
 }

--- a/src/main/java/com/zipup/server/payment/application/TossService.java
+++ b/src/main/java/com/zipup/server/payment/application/TossService.java
@@ -1,21 +1,24 @@
 package com.zipup.server.payment.application;
 
-import com.zipup.server.global.exception.BaseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.global.exception.PaymentException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import javax.annotation.PostConstruct;
 import java.util.Base64;
+import java.util.Map;
 
-import static com.zipup.server.global.exception.CustomErrorCode.DATA_NOT_FOUND;
-import static com.zipup.server.global.exception.CustomErrorCode.UNKNOWN_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @Service
 @Slf4j
@@ -23,20 +26,28 @@ public class TossService {
 
   @Value("${toss.widget.secretKey}")
   private String SECRET_KEY;
-  private final WebClient webClient;
+  @Value("${toss.widget.api.payments}")
+  private String TOSS_API;
+  private WebClient webClient;
 
-  public TossService(WebClient.Builder webClientBuilder) {
-    this.webClient = webClientBuilder.baseUrl("https://api.tosspayments.com/v1/payments").build();
-  }
-
-  public <T> Mono<T> get(String uri, Class<T> responseDtoClass) {
+  @PostConstruct
+  public void init() {
     byte[] encodedBytes = Base64.getEncoder()
             .encode((SECRET_KEY + ":").getBytes(UTF_8));
     String authorizations = "Basic " + new String(encodedBytes);
 
+    webClient = WebClient.builder()
+            .baseUrl(TOSS_API)
+            .defaultHeaders(header -> {
+                    header.set(AUTHORIZATION, authorizations);
+                    header.setContentType(APPLICATION_JSON);
+            })
+            .build();
+  }
+
+  public <T> Mono<T> get(String uri, Class<T> responseDtoClass) {
     return webClient.get()
             .uri(uri)
-            .header(AUTHORIZATION, authorizations)
             .retrieve()
             .onStatus(HttpStatus::is4xxClientError, clientResponse ->
               clientResponse.bodyToMono(ErrorResponse.class).flatMap(error ->
@@ -45,6 +56,36 @@ public class TossService {
             .onStatus(HttpStatus::is5xxServerError, clientResponse ->
                     clientResponse.bodyToMono(ErrorResponse.class).flatMap(error ->
                                     Mono.error(new PaymentException(clientResponse.statusCode().value(), error.getError_name(), error.getMessage())))
+            )
+            .bodyToMono(responseDtoClass);
+  }
+
+  public <T> Mono<T> post(String uri, Map<String, Object> request, Class<T> responseDtoClass) {
+    String idempotencyKey = request.getOrDefault("idempotencyKey", null).toString();
+    request.remove("idempotencyKey");
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String requestBody;
+    try {
+      requestBody = objectMapper.writeValueAsString(request);
+    } catch (JsonProcessingException e) {
+      return Mono.error(e);
+    }
+
+    WebClient.RequestHeadersSpec<?> requestSpec = webClient.post()
+            .uri(uri)
+            .body(BodyInserters.fromValue(requestBody));
+
+    if (!idempotencyKey.isEmpty()) requestSpec.header("Idempotency-Key", idempotencyKey);
+
+    return requestSpec.retrieve()
+            .onStatus(HttpStatus::is4xxClientError, clientResponse ->
+                    clientResponse.bodyToMono(ErrorResponse.class).flatMap(error ->
+                            Mono.error(new PaymentException(clientResponse.statusCode().value(), error.getError_name(), error.getMessage())))
+            )
+            .onStatus(HttpStatus::is5xxServerError, clientResponse ->
+                    clientResponse.bodyToMono(ErrorResponse.class).flatMap(error ->
+                            Mono.error(new PaymentException(clientResponse.statusCode().value(), error.getError_name(), error.getMessage())))
             )
             .bodyToMono(responseDtoClass);
   }

--- a/src/main/java/com/zipup/server/payment/application/TossService.java
+++ b/src/main/java/com/zipup/server/payment/application/TossService.java
@@ -1,0 +1,43 @@
+package com.zipup.server.payment.application;
+
+import com.zipup.server.global.exception.BaseException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Base64;
+
+import static com.zipup.server.global.exception.CustomErrorCode.UNKNOWN_ERROR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Service
+@Slf4j
+public class TossService {
+
+  @Value("${toss.widget.secretKey}")
+  private String SECRET_KEY;
+  private final WebClient webClient;
+
+  public TossService(WebClient.Builder webClientBuilder) {
+    this.webClient = webClientBuilder.baseUrl("https://api.tosspayments.com/v1/payments").build();
+  }
+
+  public <T> Mono<T> get(String uri, Class<T> responseDtoClass) {
+    byte[] encodedBytes = Base64.getEncoder()
+            .encode((SECRET_KEY + ":").getBytes(UTF_8));
+    String authorizations = "Basic " + new String(encodedBytes);
+
+    return webClient.get()
+            .uri(uri)
+            .header(AUTHORIZATION, authorizations)
+            .retrieve()
+            .onStatus(HttpStatus::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Internal server error occurred")))
+            .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new BaseException(UNKNOWN_ERROR)))
+            .bodyToMono(responseDtoClass);
+  }
+
+}

--- a/src/main/java/com/zipup/server/payment/domain/Payment.java
+++ b/src/main/java/com/zipup/server/payment/domain/Payment.java
@@ -2,6 +2,8 @@ package com.zipup.server.payment.domain;
 
 import com.zipup.server.global.util.converter.StringToUuidConverter;
 import com.zipup.server.global.util.entity.BaseTimeEntity;
+import com.zipup.server.global.util.entity.PaymentStatus;
+import com.zipup.server.payment.dto.CancelRecord;
 import com.zipup.server.payment.dto.PaymentResultResponse;
 import com.zipup.server.present.domain.Present;
 import lombok.*;
@@ -10,6 +12,7 @@ import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -28,6 +31,7 @@ public class Payment extends BaseTimeEntity {
   private UUID id;
 
   @Column
+  @Unique
   @NotNull(message = "결제 키 누락")
   private String paymentKey;
 
@@ -38,14 +42,35 @@ public class Payment extends BaseTimeEntity {
 
   @Column
   @NotNull(message = "결제 가격 누락")
-  private Integer price;
+  private Integer totalAmount;
+
+  @Column
+  @Setter
+  private Integer balanceAmount;
 
   @Column
   private String bank;
 
   @Column
+  private String cardNumber;
+
+  @Column
+  private String accountNumber;
+
+  @Column
+  private String phoneNumber;
+
+  @Column
+  private String easyPay;
+
+  @Column
   @NotNull(message = "결제 수단 누락")
   private String paymentMethod;
+
+  @Enumerated(EnumType.STRING)
+  @Column(columnDefinition = "ENUM('READY', 'IN_PROGRESS', 'WAITING_FOR_DEPOSIT', 'DONE', 'CANCELED', 'PARTIAL_CANCELED', 'ABORTED', 'EXPIRED') DEFAULT 'READY'")
+  @Setter
+  private PaymentStatus paymentStatus;
 
   @OneToOne(mappedBy = "payment", fetch = FetchType.LAZY)
   private Present present;
@@ -55,9 +80,20 @@ public class Payment extends BaseTimeEntity {
             .id(id.toString())
             .orderId(orderId)
             .paymentKey(paymentKey)
-            .price(price)
+            .price(balanceAmount)
             .method(paymentMethod)
-            .bank(bank)
+            .status(paymentStatus + ":" + paymentStatus.getValue())
+            .build();
+  }
+  public PaymentResultResponse toCancelResponse(List<CancelRecord> cancels) {
+    return PaymentResultResponse.builder()
+            .id(id.toString())
+            .orderId(orderId)
+            .paymentKey(paymentKey)
+            .price(balanceAmount)
+            .method(paymentMethod)
+            .status(paymentStatus + ":" + paymentStatus.getValue())
+            .cancels(cancels)
             .build();
   }
 }

--- a/src/main/java/com/zipup/server/payment/domain/Payment.java
+++ b/src/main/java/com/zipup/server/payment/domain/Payment.java
@@ -47,7 +47,7 @@ public class Payment extends BaseTimeEntity {
   @NotNull(message = "결제 수단 누락")
   private String paymentMethod;
 
-  @Transient
+  @OneToOne(mappedBy = "payment", fetch = FetchType.LAZY)
   private Present present;
 
   public PaymentResultResponse toDetailResponse() {

--- a/src/main/java/com/zipup/server/payment/dto/CancelRecord.java
+++ b/src/main/java/com/zipup/server/payment/dto/CancelRecord.java
@@ -1,0 +1,29 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CancelRecord {
+  @Schema(description = "결제 취소 금액")
+  private Integer cancelAmount;
+  @Schema(description = "결제 취소 이유")
+  private String cancelReason;
+  @Schema(description = "취소 건의 키 값")
+  private String transactionKey;
+  @Schema(description = "결제 취소가 일어난 날짜와 시간 정보")
+  private OffsetDateTime canceledAt;
+  @Schema(description = "취소 건의 현금영수증 키 값")
+  private String receiptKey;
+  @Schema(description = "취소 상태입니다. DONE이면 결제가 성공적으로 취소된 상태")
+  private String cancelStatus;
+
+}

--- a/src/main/java/com/zipup/server/payment/dto/CardInformation.java
+++ b/src/main/java/com/zipup/server/payment/dto/CardInformation.java
@@ -1,0 +1,47 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CardInformation {
+  @Schema(description = "카드사에 결제 요청한 금액")
+  private Integer cancelAmount;
+  @Schema(description = "카드 발급사 숫자 코드")
+  private String issuerCode;
+  @Schema(description = "카드 매입사 숫자 코드")
+  private String acquirerCode;
+  @Schema(description = "일부 마스킹 된 카드 번호")
+  private String number;
+  @Schema(description = "할부 개월 수. 일시불이면 0")
+  private Integer installmentPlanMonths;
+  @Schema(description = "카드사 승인 번호")
+  private String approveNo;
+  @Schema(description = "카드사 포인트 사용 여부")
+  private Boolean useCardPoint;
+  @Schema(description = "무이자 할부 적용 여부")
+  private Boolean isInterestFree;
+  @Schema(description = "카드 종류. '신용', '체크', '기프트', '미확인' 중 하나")
+  private String cardType;
+  @Schema(description = "카드의 소유자 타입. '개인', '법인', '미확인' 중 하나")
+  private String ownerType;
+  @Schema(description = "카드 결제의 매입 상태.\n" +
+          "- READY: 아직 매입 요청이 안 된 상태.\n" +
+          "- REQUESTED: 매입이 요청된 상태.\n" +
+          "- COMPLETED: 요청된 매입이 완료된 상태.\n" +
+          "- CANCEL_REQUESTED: 매입 취소가 요청된 상태.\n" +
+          "- CANCELED: 요청된 매입 취소가 완료된 상태.' 중 하나")
+  private String acquireStatus;
+  @Schema(description = "할부가 적용된 결제에서 할부 수수료를 부담하는 주체.\n" +
+          "- BUYER: 상품을 구매한 고객이 할부 수수료를 부담. 일반적인 할부 결제.\n" +
+          "- CARD_COMPANY: 카드사에서 할부 수수료를 부담. 무이자 할부 결제.\n" +
+          "- MERCHANT: 상점에서 할부 수수료를 부담. 무이자 할부 결제.'\n 중 하나")
+  private String interestPayer;
+
+}

--- a/src/main/java/com/zipup/server/payment/dto/CustomerMobilePhone.java
+++ b/src/main/java/com/zipup/server/payment/dto/CustomerMobilePhone.java
@@ -1,0 +1,16 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerMobilePhone {
+  @Schema(description = "전체 휴대폰 번호")
+  private String plain;
+  @Schema(description = "중간 4자리가 마스킹 된 휴대폰 번호")
+  private String masking;
+}

--- a/src/main/java/com/zipup/server/payment/dto/EasyPay.java
+++ b/src/main/java/com/zipup/server/payment/dto/EasyPay.java
@@ -1,0 +1,20 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EasyPay {
+  @Schema(description = "간편결제사 코드v")
+  private String provider;
+  @Schema(description = "간편결제 서비스에 등록된 계좌 혹은 현금성 포인트로 결제한 금액")
+  private Integer amount;
+  @Schema(description = "간편결제 서비스의 적립 포인트나 쿠폰 등으로 즉시 할인된 금액")
+  private Integer discountAmount;
+}

--- a/src/main/java/com/zipup/server/payment/dto/MobilePhone.java
+++ b/src/main/java/com/zipup/server/payment/dto/MobilePhone.java
@@ -1,0 +1,20 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MobilePhone {
+  @Schema(description = "휴대폰 정보")
+  private CustomerMobilePhone customerMobilePhone;
+  @Schema(description = "휴대폰 결제 내역 영수증")
+  private String receiptUrl;
+  @Schema(description = "정산 상태. 'INCOMPLETED', 'COMPLETED'")
+  private String settlementStatus;
+}

--- a/src/main/java/com/zipup/server/payment/dto/PaymentCancelRequest.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentCancelRequest.java
@@ -1,0 +1,24 @@
+package com.zipup.server.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaymentCancelRequest {
+  @Schema(description = "결제 키 값 ", required = true)
+  private String paymentKey;
+  @Schema(description = "취소 사유", required = true)
+  private String cancelReason;
+  @Schema(description = "부분 취소할 금액, 값이 없으면 전액 취소. 입금 전엔 전체 금액 취소만 가능")
+  private Integer cancelAmount;
+  @Schema(description = "결제 취소 후 환불될 계좌 정보. '가상계좌 결제만 필수', 다른 결제수단으로 이루어진 결제를 취소할 땐 Null로 주세요")
+  private RefundReceiveAccount refundReceiveAccount;
+}

--- a/src/main/java/com/zipup/server/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentConfirmRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class PaymentRequest {
+public class PaymentConfirmRequest {
   private String orderId;
   private Integer amount;
   private String paymentKey;

--- a/src/main/java/com/zipup/server/payment/dto/PaymentResultResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentResultResponse.java
@@ -34,4 +34,5 @@ public class PaymentResultResponse {
   private String orderId;
   private String paymentKey;
   private Integer price;
+  private int totalAmount;
 }

--- a/src/main/java/com/zipup/server/payment/dto/PaymentResultResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentResultResponse.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Builder
 @Data
 @AllArgsConstructor
@@ -15,24 +17,13 @@ import lombok.NoArgsConstructor;
 public class PaymentResultResponse {
   @Schema(description = "결제 식별자 값")
   private String id;
-  @Schema(description = "응답 코드")
-  private Integer code;
-  @Schema(description = "응답 메시지")
-  private String message;
   @Schema(description = "결제 방법")
   private String method;
-  @Schema(description = "결제 정보")
-  private String responseStr;
-  @Schema(description = "카드 번호")
-  private String cardNumber;
-  @Schema(description = "계좌 번호")
-  private String accountNumber;
-  @Schema(description = "은행")
-  private String bank;
-  @Schema(description = "휴대폰 결제 시")
-  private String customerMobilePhone;
   private String orderId;
   private String paymentKey;
   private Integer price;
-  private int totalAmount;
+  @Schema(description = "결제 처리 상태")
+  private String status;
+  @Schema(description = "취소 내역")
+  private List<CancelRecord> cancels;
 }

--- a/src/main/java/com/zipup/server/payment/dto/RefundReceiveAccount.java
+++ b/src/main/java/com/zipup/server/payment/dto/RefundReceiveAccount.java
@@ -1,0 +1,20 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefundReceiveAccount {
+  @Schema(description = "환불받을 계좌의 은행 코드")
+  private String bankCode;
+  @Schema(description = "환불받을 계좌번호")
+  private String accountNumber;
+  @Schema(description = "환불받을 계좌의 예금주")
+  private String holderName;
+}

--- a/src/main/java/com/zipup/server/payment/dto/RefundReceiveAccount.java
+++ b/src/main/java/com/zipup/server/payment/dto/RefundReceiveAccount.java
@@ -10,9 +10,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "가상 계좌 결제 상품을 결제 취소 시 사용되는 DTO")
 public class RefundReceiveAccount {
   @Schema(description = "환불받을 계좌의 은행 코드")
-  private String bankCode;
+  private String bank;
   @Schema(description = "환불받을 계좌번호")
   private String accountNumber;
   @Schema(description = "환불받을 계좌의 예금주")

--- a/src/main/java/com/zipup/server/payment/dto/TossPaymentResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/TossPaymentResponse.java
@@ -17,6 +17,11 @@ import java.util.List;
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TossPaymentResponse {
+
+  @Schema(description = "에러 코드")
+  private Integer code;
+  @Schema(description = "에러 메시지")
+  private String message;
   @Schema(description = "Toss Payment 객체의 날짜 기반 버저닝")
   private String version;
   @Schema(description = "결제 키 값")
@@ -49,4 +54,10 @@ public class TossPaymentResponse {
   private CardInformation card;
   @Schema(description = "가상계좌로 결제하면 제공되는 가상계좌 관련 정보")
   private VirtualAccount virtualAccount;
+  @Schema(description = "계좌 이체로 결제하면 제공되는 이체 정보")
+  private Transfer transfer;
+  @Schema(description = "휴대폰으로 결제하면 제공되는 휴대폰 결제 관련 정보")
+  private MobilePhone mobilePhone;
+  @Schema(description = "간편결제 정보")
+  private EasyPay easyPay;
 }

--- a/src/main/java/com/zipup/server/payment/dto/TossPaymentResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/TossPaymentResponse.java
@@ -1,0 +1,52 @@
+package com.zipup.server.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.zipup.server.global.util.entity.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TossPaymentResponse {
+  @Schema(description = "Toss Payment 객체의 날짜 기반 버저닝")
+  private String version;
+  @Schema(description = "결제 키 값")
+  private String paymentKey;
+  @Schema(description = "주문 번호")
+  private String orderId;
+  @Schema(description = "구매 상품")
+  private String orderName;
+  @Schema(description = "상점 아이디")
+  private String mId;
+  @Schema(description = "결제 타입 정보")
+  private String type;
+  @Schema(description = "결제 수단")
+  private String method;
+  @Schema(description = "총 결제 금액")
+  private Integer totalAmount;
+  @Schema(description = "취소 가능 금액")
+  private Integer balanceAmount;
+  @Schema(description = "결제 처리 상태")
+  private PaymentStatus status;
+  @Schema(description = "결제가 일어난 날짜와 시간 정보")
+  private OffsetDateTime requestedAt;
+  @Schema(description = "결제 승인이 일어난 날짜와 시간 정보")
+  private OffsetDateTime approvedAt;
+  @Schema(description = "마지막 거래의 키 값. 한 결제 건의 승인 거래와 취소 거래를 구분하는 데 사용")
+  private String lastTransactionKey;
+  @Schema(description = "결제 취소 이력")
+  private List<CancelRecord> cancels;
+  @Schema(description = "카드로 결제하면 제공되는 카드 관련 정보")
+  private CardInformation card;
+  @Schema(description = "가상계좌로 결제하면 제공되는 가상계좌 관련 정보")
+  private VirtualAccount virtualAccount;
+}

--- a/src/main/java/com/zipup/server/payment/dto/Transfer.java
+++ b/src/main/java/com/zipup/server/payment/dto/Transfer.java
@@ -1,0 +1,18 @@
+package com.zipup.server.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Transfer {
+  @Schema(description = "가상계좌 은행 숫자 코드")
+  private String bankCode;
+  @Schema(description = "정산 상태. 'INCOMPLETED', 'COMPLETED'")
+  private String settlementStatus;
+}

--- a/src/main/java/com/zipup/server/payment/dto/VirtualAccount.java
+++ b/src/main/java/com/zipup/server/payment/dto/VirtualAccount.java
@@ -1,0 +1,33 @@
+package com.zipup.server.payment.dto;
+
+import com.zipup.server.global.util.entity.RefundStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class VirtualAccount {
+  @Schema(description = "가상계좌 타입. '일반', '고정' 중 하나")
+  private String accountType;
+  @Schema(description = "발급된 계좌번호")
+  private String accountNumber;
+  @Schema(description = "가상계좌 은행 숫자 코드")
+  private String bankCode;
+  @Schema(description = "가상계좌를 발급한 구매자명")
+  private String customerName;
+  @Schema(description = "입금 기한")
+  private OffsetDateTime dueDate;
+  @Schema(description = "환불 처리 상태")
+  private RefundStatus refundStatus;
+  @Schema(description = "가상계좌의 만료 여부")
+  private Boolean expired;
+  @Schema(description = "환불 계좌 정보")
+  private RefundReceiveAccount refundReceiveAccount;
+}

--- a/src/main/java/com/zipup/server/payment/dto/VirtualAccount.java
+++ b/src/main/java/com/zipup/server/payment/dto/VirtualAccount.java
@@ -22,6 +22,8 @@ public class VirtualAccount {
   private String bankCode;
   @Schema(description = "가상계좌를 발급한 구매자명")
   private String customerName;
+  @Schema(description = "정산 상태. 'INCOMPLETED', 'COMPLETED'")
+  private String settlementStatus;
   @Schema(description = "입금 기한")
   private OffsetDateTime dueDate;
   @Schema(description = "환불 처리 상태")

--- a/src/main/java/com/zipup/server/payment/infrastructure/PaymentRepository.java
+++ b/src/main/java/com/zipup/server/payment/infrastructure/PaymentRepository.java
@@ -4,8 +4,10 @@ import com.zipup.server.payment.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+  Optional<Payment> findByPaymentKey(String paymentKey);
 }

--- a/src/main/java/com/zipup/server/payment/infrastructure/PaymentRepository.java
+++ b/src/main/java/com/zipup/server/payment/infrastructure/PaymentRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, UUID> {
   Optional<Payment> findByPaymentKey(String paymentKey);
+  Boolean existsByPaymentKey(String paymentKey);
+  Boolean existsByOrderId(String orderId);
 }

--- a/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
@@ -2,8 +2,9 @@ package com.zipup.server.payment.presentation;
 
 import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.payment.application.PaymentService;
-import com.zipup.server.payment.dto.PaymentRequest;
+import com.zipup.server.payment.dto.PaymentConfirmRequest;
 import com.zipup.server.payment.dto.PaymentResultResponse;
+import com.zipup.server.payment.dto.TossPaymentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -49,22 +50,6 @@ public class PaymentController {
             : ResponseEntity.status(HttpStatus.CONFLICT).body("동일한 주문 번호가 존재해요.");
   }
 
-  @Operation(summary = "결제 실패", description = "결제 실패")
-  @Parameter(name = "message", description = "결제 실패")
-  @Parameter(name = "code", description = "400")
-  @ApiResponse(
-          responseCode = "400",
-          description = "결제 실패",
-          content = @Content(schema = @Schema(type = "Payment failed")))
-  @GetMapping(value = "/fail")
-  public ResponseEntity<String> failPayment(
-          @RequestParam(value = "message") String message,
-          @RequestParam(value = "code") Integer code
-  ) {
-    log.error("message : {}\ncode : {} " + message, code);
-    return ResponseEntity.status(code).body(message);
-  }
-
   @Operation(summary = "결제 성공 여부", description = "서버에서 토스페이먼츠로 결제 승인 요청")
   @Parameter(name = "orderId", description = "주문 번호")
   @Parameter(name = "amount", description = "결제 금액")
@@ -89,7 +74,7 @@ public class PaymentController {
           @RequestParam(value = "amount") Integer amount,
           @RequestParam(value = "paymentKey") String paymentKey) throws Exception {
 
-    PaymentResultResponse response = paymentService.successPayment(new PaymentRequest(orderId, amount, paymentKey));
+    PaymentResultResponse response = paymentService.successPayment(new PaymentConfirmRequest(orderId, amount, paymentKey));
 
     return ResponseEntity.status(response.getCode()).body(response);
   }
@@ -100,7 +85,7 @@ public class PaymentController {
           @ApiResponse(
                   responseCode = "200",
                   description = "조회 성공",
-                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+                  content = @Content(schema = @Schema(implementation = TossPaymentResponse.class))),
           @ApiResponse(
                   responseCode = "401",
                   description = "인증되지 않은 시크릿 키 혹은 클라이언트 키",
@@ -115,10 +100,9 @@ public class PaymentController {
                   content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
   })
   @GetMapping(value = "/key")
-  public ResponseEntity<PaymentResultResponse> getPaymentByPaymentKey(@RequestParam(value = "paymentKey") String paymentKey) throws Exception {
-    PaymentResultResponse response = paymentService.fetchPaymentByPaymentKey(paymentKey);
-
-    return ResponseEntity.ok().body(response);
+  public ResponseEntity<TossPaymentResponse> getPaymentByPaymentKey(@RequestParam(value = "paymentKey") String paymentKey) {
+    return ResponseEntity.ok()
+            .body(paymentService.fetchPaymentByPaymentKey(paymentKey));
   }
 
   @Operation(summary = "orderId로 결제 조회", description = "orderId로 결제 조회")
@@ -127,7 +111,7 @@ public class PaymentController {
           @ApiResponse(
                   responseCode = "200",
                   description = "저장 성공",
-                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+                  content = @Content(schema = @Schema(implementation = TossPaymentResponse.class))),
           @ApiResponse(
                   responseCode = "401",
                   description = "인증되지 않은 시크릿 키 혹은 클라이언트 키",
@@ -142,10 +126,9 @@ public class PaymentController {
                   content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
   })
   @GetMapping(value = "/order")
-  public ResponseEntity<PaymentResultResponse> getPaymentByOrderId(@RequestParam(value = "orderId") String orderId) throws Exception {
-      PaymentResultResponse response = paymentService.fetchPaymentByOrderId(orderId);
-
-    return ResponseEntity.ok().body(response);
+  public ResponseEntity<TossPaymentResponse> getPaymentByOrderId(@RequestParam(value = "orderId") String orderId) {
+    return ResponseEntity.ok()
+            .body(paymentService.fetchPaymentByOrderId(orderId));
   }
 
   @Operation(summary = "임시 데이터", description = "임시")

--- a/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
@@ -2,6 +2,7 @@ package com.zipup.server.payment.presentation;
 
 import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.payment.application.PaymentService;
+import com.zipup.server.payment.dto.PaymentCancelRequest;
 import com.zipup.server.payment.dto.PaymentConfirmRequest;
 import com.zipup.server.payment.dto.PaymentResultResponse;
 import com.zipup.server.payment.dto.TossPaymentResponse;
@@ -77,6 +78,33 @@ public class PaymentController {
     PaymentResultResponse response = paymentService.successPayment(new PaymentConfirmRequest(orderId, amount, paymentKey));
 
     return ResponseEntity.status(response.getCode()).body(response);
+  }
+
+  @Operation(summary = "결제 취소", description = "paymentKey로 결제 취소")
+  @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "승인된 결제를 paymentKey로 취소합니다. 취소 이유를 cancelReason에 추가해야 합니다.\n" +
+          "결제 금액의 일부만 부분 취소하려면 cancelAmount에 취소할 금액을 추가해서 API를 요청합니다. cancelAmount에 값을 넣지 않으면 전액 취소됩니다.")
+  @ApiResponses(value = {
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "저장 성공",
+                  content = @Content(schema = @Schema(implementation = TossPaymentResponse.class))),
+          @ApiResponse(
+                  responseCode = "401",
+                  description = "인증되지 않은 시크릿 키 혹은 클라이언트 키",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "403",
+                  description = "반복적인 요청은 허용되지 않음",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "404",
+                  description = "존재하지 않는 결제 정보",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @PostMapping(value = "/cancel")
+  public ResponseEntity<TossPaymentResponse> cancelPayment(@RequestBody PaymentCancelRequest request) {
+    return ResponseEntity.ok()
+            .body(paymentService.cancelPayment(request));
   }
 
   @Operation(summary = "paymentKey로 결제 조회", description = "paymentKey로 결제 조회")

--- a/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
@@ -1,5 +1,6 @@
 package com.zipup.server.payment.presentation;
 
+import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.payment.application.PaymentService;
 import com.zipup.server.payment.dto.PaymentRequest;
 import com.zipup.server.payment.dto.PaymentResultResponse;
@@ -91,6 +92,60 @@ public class PaymentController {
     PaymentResultResponse response = paymentService.successPayment(new PaymentRequest(orderId, amount, paymentKey));
 
     return ResponseEntity.status(response.getCode()).body(response);
+  }
+
+  @Operation(summary = "paymentKey로 결제 조회", description = "paymentKey로 결제 조회")
+  @Parameter(name = "paymentKey", description = "결제 키")
+  @ApiResponses(value = {
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "조회 성공",
+                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+          @ApiResponse(
+                  responseCode = "401",
+                  description = "인증되지 않은 시크릿 키 혹은 클라이언트 키",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "403",
+                  description = "반복적인 요청은 허용되지 않음",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "404",
+                  description = "존재하지 않는 결제 정보",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @GetMapping(value = "/key")
+  public ResponseEntity<PaymentResultResponse> getPaymentByPaymentKey(@RequestParam(value = "paymentKey") String paymentKey) throws Exception {
+    PaymentResultResponse response = paymentService.fetchPaymentByPaymentKey(paymentKey);
+
+    return ResponseEntity.ok().body(response);
+  }
+
+  @Operation(summary = "orderId로 결제 조회", description = "orderId로 결제 조회")
+  @Parameter(name = "orderId", description = "주문 정보 키")
+  @ApiResponses(value = {
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "저장 성공",
+                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+          @ApiResponse(
+                  responseCode = "401",
+                  description = "인증되지 않은 시크릿 키 혹은 클라이언트 키",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "403",
+                  description = "반복적인 요청은 허용되지 않음",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+                  responseCode = "404",
+                  description = "존재하지 않는 결제 정보",
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @GetMapping(value = "/order")
+  public ResponseEntity<PaymentResultResponse> getPaymentByOrderId(@RequestParam(value = "orderId") String orderId) throws Exception {
+      PaymentResultResponse response = paymentService.fetchPaymentByOrderId(orderId);
+
+    return ResponseEntity.ok().body(response);
   }
 
   @Operation(summary = "임시 데이터", description = "임시")

--- a/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
@@ -2,10 +2,7 @@ package com.zipup.server.payment.presentation;
 
 import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.payment.application.PaymentService;
-import com.zipup.server.payment.dto.PaymentCancelRequest;
-import com.zipup.server.payment.dto.PaymentConfirmRequest;
-import com.zipup.server.payment.dto.PaymentResultResponse;
-import com.zipup.server.payment.dto.TossPaymentResponse;
+import com.zipup.server.payment.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -51,7 +48,7 @@ public class PaymentController {
             : ResponseEntity.status(HttpStatus.CONFLICT).body("동일한 주문 번호가 존재해요.");
   }
 
-  @Operation(summary = "결제 성공 여부", description = "서버에서 토스페이먼츠로 결제 승인 요청")
+  @Operation(summary = "결제 승인", description = "서버에서 토스페이먼츠로 결제 승인 요청")
   @Parameter(name = "orderId", description = "주문 번호")
   @Parameter(name = "amount", description = "결제 금액")
   @Parameter(name = "paymentKey", description = "결제 키")
@@ -63,30 +60,30 @@ public class PaymentController {
           @ApiResponse(
                   responseCode = "401",
                   description = "키 오류",
-                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(
                   responseCode = "404",
                   description = "결제 시간 만료",
-                  content = @Content(schema = @Schema(implementation = PaymentResultResponse.class))),
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
   })
   @GetMapping(value = "/confirm")
   public ResponseEntity<PaymentResultResponse> successPayment(
           @RequestParam(value = "orderId") String orderId,
           @RequestParam(value = "amount") Integer amount,
-          @RequestParam(value = "paymentKey") String paymentKey) throws Exception {
+          @RequestParam(value = "paymentKey") String paymentKey) {
 
-    PaymentResultResponse response = paymentService.successPayment(new PaymentConfirmRequest(orderId, amount, paymentKey));
+    PaymentResultResponse response = paymentService.confirmPayment(new PaymentConfirmRequest(orderId, amount, paymentKey));
 
-    return ResponseEntity.status(response.getCode()).body(response);
+    return ResponseEntity.ok().body(response);
   }
 
-  @Operation(summary = "결제 취소", description = "paymentKey로 결제 취소")
-  @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "승인된 결제를 paymentKey로 취소합니다. 취소 이유를 cancelReason에 추가해야 합니다.\n" +
-          "결제 금액의 일부만 부분 취소하려면 cancelAmount에 취소할 금액을 추가해서 API를 요청합니다. cancelAmount에 값을 넣지 않으면 전액 취소됩니다.")
+  @Operation(summary = "결제 취소", description = "paymentKey 로 결제 취소")
+  @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "승인된 결제를 paymentKey 로 취소합니다. 취소 이유를 cancelReason 에 추가해야 합니다.\n" +
+          "결제 금액의 일부만 부분 취소하려면 cancelAmount 에 취소할 금액을 추가해서 API 요청합니다. cancelAmount 에 값을 넣지 않으면 전액 취소됩니다.")
   @ApiResponses(value = {
           @ApiResponse(
                   responseCode = "200",
-                  description = "저장 성공",
+                  description = "결제 취소에 성공하면 TossPaymentResponse 객체의 cancels 키에 취소 기록을 배열로 드립니다.\n각 취소 거래마다 거래를 구분하는 transactionKey 를 가지고 있습니다.",
                   content = @Content(schema = @Schema(implementation = TossPaymentResponse.class))),
           @ApiResponse(
                   responseCode = "401",
@@ -102,12 +99,12 @@ public class PaymentController {
                   content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
   })
   @PostMapping(value = "/cancel")
-  public ResponseEntity<TossPaymentResponse> cancelPayment(@RequestBody PaymentCancelRequest request) {
+  public ResponseEntity<PaymentResultResponse> cancelPayment(@RequestBody PaymentCancelRequest request) {
     return ResponseEntity.ok()
             .body(paymentService.cancelPayment(request));
   }
 
-  @Operation(summary = "paymentKey로 결제 조회", description = "paymentKey로 결제 조회")
+  @Operation(summary = "paymentKey 로 결제 조회", description = "paymentKey 로 결제 조회")
   @Parameter(name = "paymentKey", description = "결제 키")
   @ApiResponses(value = {
           @ApiResponse(

--- a/src/main/java/com/zipup/server/present/domain/Present.java
+++ b/src/main/java/com/zipup/server/present/domain/Present.java
@@ -50,7 +50,7 @@ public class Present extends BaseTimeEntity {
   private Payment payment;
 
   public PresentSummaryResponse toSummaryResponse() {
-    int percentage = (int) Math.round(((double) payment.getPrice() / fund.getGoalPrice()) * 100);
+    int percentage = (int) Math.round(((double) payment.getBalanceAmount() / fund.getGoalPrice()) * 100);
 
     return PresentSummaryResponse.builder()
             .id(id.toString())

--- a/src/main/java/com/zipup/server/present/domain/Present.java
+++ b/src/main/java/com/zipup/server/present/domain/Present.java
@@ -45,7 +45,8 @@ public class Present extends BaseTimeEntity {
   @Setter
   private Fund fund;
 
-  @OneToOne(fetch = FetchType.EAGER)
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @JoinColumn(name = "payment_id", referencedColumnName = "payment_id")
   private Payment payment;
 
   public PresentSummaryResponse toSummaryResponse() {

--- a/src/test/java/com/zipup/server/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/zipup/server/payment/application/PaymentServiceTest.java
@@ -33,7 +33,7 @@ public class PaymentServiceTest {
     payment = Payment.builder()
             .paymentKey("paymentKey")
             .paymentMethod("가상계좌")
-            .price(45000)
+            .totalAmount(45000)
             .bank("88")
             .build();
     savedEntity = paymentRepository.save(payment);

--- a/src/test/java/com/zipup/server/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/zipup/server/payment/application/PaymentServiceTest.java
@@ -1,0 +1,63 @@
+package com.zipup.server.payment.application;
+
+import com.zipup.server.global.exception.ResourceNotFoundException;
+import com.zipup.server.payment.domain.Payment;
+import com.zipup.server.payment.dto.PaymentCancelRequest;
+import com.zipup.server.payment.dto.RefundReceiveAccount;
+import com.zipup.server.payment.infrastructure.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class PaymentServiceTest {
+  @Autowired
+  private PaymentService paymentService;
+  @Mock
+  private PaymentRepository paymentRepository;
+
+  private Payment payment;
+  private Payment savedEntity;
+  private PaymentCancelRequest request;
+
+
+  @BeforeEach
+  void setUp() {
+    payment = Payment.builder()
+            .paymentKey("paymentKey")
+            .paymentMethod("가상계좌")
+            .price(45000)
+            .bank("88")
+            .build();
+    savedEntity = paymentRepository.save(payment);
+
+    RefundReceiveAccount account = RefundReceiveAccount.builder()
+            .accountNumber("accountNumber")
+            .bank("88")
+            .holderName("김토스")
+            .build();
+
+    request = new PaymentCancelRequest(
+            "paymentKey",
+            "cancelReason",
+            10000,
+            account
+    );
+  }
+
+  @Test
+  void cancelPayment_PaymentNotFound_ThrowsResourceNotFoundException() {
+    // given
+    when(paymentRepository.findByPaymentKey("invalidKey")).thenReturn(Optional.empty());
+    // when, then
+    assertThrows(ResourceNotFoundException.class, () -> paymentService.cancelPayment(request));
+  }
+
+}


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 토스의 Payment 객체 및 여러 응답 객체 DTO로 생성
 - 결제 취소 API 구현
 - 토스 통신용 Service 객체 구현
 - 결제 승인 요청 API와 취소 API 모두 WebClient로 토스 요청하도록 변경