### PR TITLE
[fix] #119 회원 id로 펀딩 참여, 주최 리스트 조회 로직에서 userId jwt로 전환

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -4,6 +4,7 @@ import com.zipup.server.funding.domain.Fund;
 import com.zipup.server.funding.dto.*;
 import com.zipup.server.funding.infrastructure.FundRepository;
 import com.zipup.server.global.exception.ResourceNotFoundException;
+import com.zipup.server.global.security.util.AuthenticationUtil;
 import com.zipup.server.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -54,6 +55,7 @@ public class FundService {
 
   @Transactional(readOnly = true)
   public List<FundingSummaryResponse> getMyFundingList(String userId) {
+    if (userId == null || userId.isEmpty()) userId = getZipupAuthentication().getName();
     isValidUUID(userId);
     return fundRepository.findAllByUser(userService.findById(userId))
             .stream()

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -47,7 +47,7 @@ public class FundController {
           description = "조회 성공",
           content = @Content(schema = @Schema(implementation = FundingSummaryResponse.class)))
   @GetMapping("/list")
-  public ResponseEntity<List<FundingSummaryResponse>> getMyFundingList(@RequestParam(value = "user") String userId) {
+  public ResponseEntity<List<FundingSummaryResponse>> getMyFundingList(@RequestParam(value = "user", required = false) String userId) {
     return ResponseEntity.ok(fundService.getMyFundingList(userId));
   }
 

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -7,6 +7,7 @@ import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.global.exception.PaymentException;
 import com.zipup.server.global.exception.ResourceNotFoundException;
+import com.zipup.server.global.security.util.AuthenticationUtil;
 import com.zipup.server.global.util.entity.ColumnStatus;
 import com.zipup.server.payment.application.PaymentService;
 import com.zipup.server.payment.domain.Payment;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.zipup.server.global.exception.CustomErrorCode.ACCESS_DENIED;
@@ -78,6 +80,7 @@ public class PresentService {
 
   @Transactional(readOnly = true)
   public List<FundingSummaryResponse> getMyParticipateList(String userId) {
+    if (userId == null || userId.isEmpty()) userId = AuthenticationUtil.getZipupAuthentication().getName();
     isValidUUID(userId);
     return presentRepository.findAllByUserAndStatus(userService.findById(userId), ColumnStatus.PUBLIC)
             .stream()

--- a/src/main/java/com/zipup/server/present/presentation/PresentController.java
+++ b/src/main/java/com/zipup/server/present/presentation/PresentController.java
@@ -64,7 +64,7 @@ public class PresentController {
           description = "조회 성공",
           content = @Content(schema = @Schema(implementation = FundingSummaryResponse.class)))
   @GetMapping("/list")
-  public ResponseEntity<List<FundingSummaryResponse>> getMyParticipateList(@RequestParam(value = "user") String userId) {
+  public ResponseEntity<List<FundingSummaryResponse>> getMyParticipateList(@RequestParam(value = "user", required = false) String userId) {
     return ResponseEntity.ok(presentService.getMyParticipateList(userId));
   }
 

--- a/src/test/java/com/zipup/server/present/presentation/PresentControllerTest.java
+++ b/src/test/java/com/zipup/server/present/presentation/PresentControllerTest.java
@@ -1,9 +1,7 @@
-package com.zipup.server.funding.presentaion;
+package com.zipup.server.present.presentation;
 
-import com.zipup.server.funding.application.CrawlerService;
-import com.zipup.server.funding.application.FundService;
 import com.zipup.server.funding.dto.FundingSummaryResponse;
-import com.zipup.server.funding.presentation.FundController;
+import com.zipup.server.present.application.PresentService;
 import com.zipup.server.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,19 +22,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class FundControllerTest {
+public class PresentControllerTest {
 
   @Mock
-  private CrawlerService crawlerService;
-  @Mock
-  private FundService fundService;
+  private PresentService presentService;
   @Autowired
   private MockMvc mockMvc;
   @Autowired
@@ -53,29 +47,15 @@ public class FundControllerTest {
     entityManager.flush();
     userId = user.getId().toString();
 
-    mockMvc = MockMvcBuilders.standaloneSetup(new FundController(fundService, crawlerService)).build();
+    mockMvc = MockMvcBuilders.standaloneSetup(new PresentController(presentService)).build();
   }
 
   @Test
-  @WithMockUser(authorities = {"ROLE_USER"})
-  void testCrawlingProductInfo() throws Exception {
-    String url = "https://www.apple.com/kr/shop/buy-mac/macbook-air/13%ED%98%95-%EB%AF%B8%EB%93%9C%EB%82%98%EC%9D%B4%ED%8A%B8-apple-m3-%EC%B9%A9(8%EC%BD%94%EC%96%B4-cpu-%EB%B0%8F-8%EC%BD%94%EC%96%B4-gpu)-8gb-%EB%A9%94%EB%AA%A8%EB%A6%AC-256gb";
-
-    // 요청 및 응답 확인
-    mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/fund/crawler")
-                    .param("product", url)
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
-
-    verify(crawlerService, times(1)).crawlingProductInfo(url);
-  }
-
-  @Test
-  public void testGetMyFundingList() throws Exception {
+  public void testGetMyParticipateList() throws Exception {
     List<FundingSummaryResponse> mockResponses = new ArrayList<>();
-    given(fundService.getMyFundingList(userId)).willReturn(mockResponses);
+    given(presentService.getMyParticipateList(userId)).willReturn(mockResponses);
 
-    mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/fund/list")
+    mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/present/list")
                     .param("user", userId)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -84,11 +64,11 @@ public class FundControllerTest {
 
   @Test
   @WithMockUser(authorities = {"ROLE_USER"})
-  public void testGetMyFundingList_NoUserId() throws Exception {
+  public void testGetMyParticipateList_NoUserId() throws Exception {
     List<FundingSummaryResponse> mockResponses = new ArrayList<>();
-    given(fundService.getMyFundingList(null)).willReturn(mockResponses);
+    given(presentService.getMyParticipateList(null)).willReturn(mockResponses);
 
-    mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/fund/list")
+    mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/present/list")
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON));


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - userId를 받을 수는 있으나 필수적으로 받지 않아도 되도록 구현
 - 테스트 코드 구현