### PR TITLE
[fix] #109 결제 승인 시 401 에러 수정

### DIFF
--- a/src/main/java/com/zipup/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/zipup/server/global/security/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
 
             .authorizeRequests(authorizeRequests ->
                     authorizeRequests
+                            .antMatchers(HttpMethod.GET, "/api/v1/payment/confirm").authenticated()
                             .antMatchers(HttpMethod.GET).permitAll()
                             .antMatchers(HttpMethod.POST, AUTH_WHITELIST).permitAll()
                             .anyRequest().authenticated())


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - security config에서 payment api authenticated로 거르기