### PR TITLE
[fix] #123 회원 탈퇴 swagger 응답 예시 수정

### DIFF
--- a/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zipup/server/global/security/filter/JwtAuthenticationFilter.java
@@ -61,15 +61,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         Authentication authentication = jwtProvider.getAuthenticationByToken(accessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-//      } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-//        log.error("jwt authentication filter :: {} {} {}", WRONG_TYPE_TOKEN.getMessage(), StringUtils.hasText(accessToken), requestURI);
-//        request.setAttribute("exception", WRONG_TYPE_TOKEN);
-//        errorJson = objectMapper.writeValueAsString(ErrorResponse.toErrorResponse(WRONG_TYPE_TOKEN));
+      } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+        log.error("jwt authentication filter :: {} {} {}", WRONG_TYPE_TOKEN.getMessage(), StringUtils.hasText(accessToken), requestURI);
+        request.setAttribute("exception", WRONG_TYPE_TOKEN);
+        errorJson = objectMapper.writeValueAsString(ErrorResponse.toErrorResponse(WRONG_TYPE_TOKEN));
 
-//        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-//        response.setContentType("application/json;charset=UTF-8");
-//        response.getWriter().write(errorJson);
-//        return;
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(errorJson);
+        return;
       } catch (DecodingException | UnsupportedJwtException e) {
         log.error("jwt authentication filter :: {} {} {}", UNSUPPORTED_TOKEN.getMessage(), StringUtils.hasText(accessToken), requestURI);
         request.setAttribute("exception", UNSUPPORTED_TOKEN);

--- a/src/main/java/com/zipup/server/user/facade/UserFundFacade.java
+++ b/src/main/java/com/zipup/server/user/facade/UserFundFacade.java
@@ -50,7 +50,7 @@ public class UserFundFacade implements UserFacade<Fund> {
             .map(Fund::toSummaryResponse)
             .noneMatch(response -> response.getPercent() < 100 && !response.getStatus().equals("완료"));
 
-//    if (!hasActiveFunding) throw new UserException(ACTIVE_FUNDING, userId);
+    if (!hasActiveFunding) throw new UserException(ACTIVE_FUNDING, userId);
     fundList.forEach(fund -> fund.setStatus(ColumnStatus.PRIVATE));
     targetUser.setWithdrawalReason(request.getWithdrawalReason());
     userService.unlinkStatusUser(targetUser);

--- a/src/main/java/com/zipup/server/user/presentation/UserController.java
+++ b/src/main/java/com/zipup/server/user/presentation/UserController.java
@@ -2,7 +2,7 @@ package com.zipup.server.user.presentation;
 
 import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.exception.BaseException;
-import com.zipup.server.global.exception.UserException;
+import com.zipup.server.global.exception.ErrorResponse;
 import com.zipup.server.global.security.util.JwtProvider;
 import com.zipup.server.user.application.UserService;
 import com.zipup.server.user.dto.*;
@@ -102,7 +102,7 @@ public class UserController {
           @ApiResponse(responseCode = "200", description = "회원 정보",
                   content = @Content(schema = @Schema(implementation = SimpleDataResponse.class))),
           @ApiResponse(responseCode = "403", description = "진행 중인 펀딩 존재",
-                  content = @Content(schema = @Schema(implementation = UserException.class))),
+                  content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
   })
   @PutMapping("/withdrawal")
   public ResponseEntity<SimpleDataResponse> unlinkUser(


### PR DESCRIPTION
## 💡 구현할 기능 설명
- 회원 탈퇴 swagger 응답 예시 통일된 객체로 수정
- 진행 중인 펀딩 있으면 회원 탈퇴 못하게 막는 로직 추가
- JWT 인증 필터 MalformedJwtException 예외 catch 다시 추가