### PR TITLE
[fix] #109 결제 status 자동 update api 우선 ready 상태만 업데이트 하도록 구현

### DIFF
--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -3,6 +3,7 @@ package com.zipup.server.payment.application;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.global.exception.ResourceNotFoundException;
 import com.zipup.server.global.exception.UniqueConstraintException;
+import com.zipup.server.global.util.entity.PaymentStatus;
 import com.zipup.server.payment.domain.Payment;
 import com.zipup.server.payment.dto.PaymentCancelRequest;
 import com.zipup.server.payment.dto.PaymentConfirmRequest;
@@ -141,7 +142,10 @@ public class PaymentService {
 
   @Transactional
   public void updatePaymentStatus() {
-    getPaymentList().forEach(payment -> fetchPaymentByPaymentKey(payment.getPaymentKey()));
+    getPaymentList()
+            .stream()
+            .filter(payment -> payment.getStatus().equals(PaymentStatus.READY))
+            .forEach(payment -> fetchPaymentByPaymentKey(payment.getPaymentKey()));
   }
 
   @Transactional

--- a/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/zipup/server/payment/presentation/PaymentController.java
@@ -224,7 +224,7 @@ public class PaymentController {
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "임시 데이터", description = "임시")
+  @Operation(summary = "결제 데이터 업데이트", description = "결제 데이터 업데이트")
   @PutMapping("/setting")
   public ResponseEntity<Void> updatePaymentStatus(
           final HttpServletRequest httpServletRequest


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 우선 ready status만 업데이트 하도록 구현