### PR TITLE
[fix] #109 결제 내역 조회 시 응답 프로퍼티 추가

### DIFF
--- a/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/zipup/server/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -25,8 +25,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 
   @Override
   public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-    System.out.println("loadAuthorizationRequest :: " + request.getHeader("Referer"));
-
     return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
             .map(cookie -> {
               try {
@@ -42,8 +40,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 
   @Override
   public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
-    System.out.println("saveAuthorizationRequest :: " + request.getHeader("Referer"));
-
     if (authorizationRequest == null) {
       CookieUtil.deleteCookie(request, response, HttpHeaders.AUTHORIZATION);
       CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);

--- a/src/main/java/com/zipup/server/payment/domain/Payment.java
+++ b/src/main/java/com/zipup/server/payment/domain/Payment.java
@@ -99,7 +99,7 @@ public class Payment extends BaseTimeEntity {
             .build();
   }
 
-  public PaymentHistoryResponse toHistoryResponse(Boolean refundable) {
+  public PaymentHistoryResponse toHistoryResponse(Boolean isVirtualAccountAndDepositCompleted, Boolean refundable) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     String historyStatus = getStatusText(paymentStatus);
     String paymentNumber = id.toString().replaceAll("-", "");
@@ -113,6 +113,7 @@ public class Payment extends BaseTimeEntity {
             .amount(balanceAmount)
             .paymentNumber(paymentNumber.substring(0, Math.min(15, paymentNumber.length())))
             .refundable(refundable)
+            .isVirtualAccountAndDepositCompleted(isVirtualAccountAndDepositCompleted)
             .build();
   }
 

--- a/src/main/java/com/zipup/server/payment/dto/PaymentHistoryResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentHistoryResponse.java
@@ -27,4 +27,6 @@ public class PaymentHistoryResponse {
   private String status;
   @Schema(description = "결제 취소 가능 여부")
   private Boolean refundable;
+  @Schema(description = "결제 수단이 가상계좌이면서 입금 처리까지 완료됐는지 여부")
+  private Boolean isVirtualAccountAndDepositCompleted;
 }


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 결제 내역 조회 시 가상계좌이면서 입금 완료인 경우에 대한 응답 프로퍼티 추가