### PR TITLE
[feat] #159 주최자 펀딩 삭제 구현

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -51,7 +51,7 @@ public class FundService {
             : crawlerResponse.getImageUrl() == null ? ""
             : !crawlerResponse.getImageUrl().startsWith("https:")
             ? "https:" + crawlerResponse.getImageUrl() : crawlerResponse.getImageUrl();
-    targetFund.setImageUrl(imageUrl);
+    setImageUrl(targetFund, imageUrl);
 
     Fund response = fundRepository.save(targetFund);
 
@@ -81,6 +81,26 @@ public class FundService {
             .stream()
             .map(Fund::toSummaryResponse)
             .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void changePrivateFunding(Fund fund) {
+    fund.setStatus(ColumnStatus.PRIVATE);
+  }
+
+  @Transactional
+  public void changeUnlinkFunding(Fund fund) {
+    fund.setStatus(ColumnStatus.UNLINK);
+  }
+
+  @Transactional
+  public void setFundCancelReason(Fund fund, String cancelReason) {
+    fund.setCancelReason(cancelReason);
+  }
+
+  @Transactional
+  public void setImageUrl(Fund fund, String imageUrl) {
+    fund.setImageUrl(imageUrl);
   }
 
 }

--- a/src/main/java/com/zipup/server/funding/domain/Fund.java
+++ b/src/main/java/com/zipup/server/funding/domain/Fund.java
@@ -63,6 +63,10 @@ public class Fund extends BaseTimeEntity {
   @Setter
   private String imageUrl;
 
+  @Column
+  @Setter
+  private String cancelReason;
+
   @Enumerated(EnumType.STRING)
   @Column(columnDefinition = "ENUM('CHUNSIK')")
   private GiftCard card;

--- a/src/main/java/com/zipup/server/funding/dto/FundingCancelRequest.java
+++ b/src/main/java/com/zipup/server/funding/dto/FundingCancelRequest.java
@@ -1,0 +1,18 @@
+package com.zipup.server.funding.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class FundingCancelRequest {
+  @Schema(description = "주최자 id")
+  private String userId;
+  @Schema(description = "펀딩 id")
+  private String fundingId;
+  @Schema(description = "취소 사유", required = true)
+  private String cancelReason;
+}

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -5,6 +5,7 @@ import com.zipup.server.funding.application.FundService;
 import com.zipup.server.funding.dto.*;
 import com.zipup.server.global.exception.BaseException;
 import com.zipup.server.global.security.util.JwtProvider;
+import com.zipup.server.present.dto.PresentSummaryResponse;
 import com.zipup.server.user.facade.UserFacade;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -131,6 +132,31 @@ public class FundController {
 
     request.setUserId(userId);
     return ResponseEntity.ok().body(fundService.createFunding(request));
+  }
+
+  @Operation(summary = "주최자 - 펀딩 삭제", description = "주최자 - 펀딩 삭제")
+  @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "펀딩 취소 요청. 주최자 id는 비워서 요청하시면 됩니다.")
+  @ApiResponses(value = {
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "펀딩 삭제 성공",
+                  content = @Content(schema = @Schema(type = "펀딩 삭제 성공", implementation = PresentSummaryResponse.class)))
+  })
+  @PutMapping("/cancel")
+  public ResponseEntity<List<PresentSummaryResponse>> cancelFunding(
+          final HttpServletRequest httpServletRequest,
+          final HttpServletResponse httpServletResponse,
+          @RequestBody FundingCancelRequest request
+  ) {
+    String accessToken = jwtProvider.resolveToken(httpServletRequest);
+    if (!StringUtils.hasText(accessToken)) throw new BaseException(EMPTY_ACCESS_JWT);
+    if (jwtProvider.validateToken(accessToken)) throw new BaseException(EXPIRED_TOKEN);
+    Authentication authentication = jwtProvider.getAuthenticationByToken(accessToken);
+    String userId = authentication.getName();
+    isValidUUID(userId);
+
+    request.setUserId(userId);
+    return ResponseEntity.ok(userFacade.deleteEntity(request));
   }
 
   @Operation(summary = "임시 데이터", description = "임시")

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -116,6 +116,7 @@ public class PresentService {
 
     paymentService.cancelPayment(paymentCancelRequest);
     changePrivateParticipate(targetPresent);
+    setPresentCancelReason(targetPresent, request.getCancelReason());
 
     return "취소 성공";
   }
@@ -148,6 +149,11 @@ public class PresentService {
   @Transactional
   public void changeUnlinkParticipate(Present present) {
     present.setStatus(ColumnStatus.UNLINK);
+  }
+
+  @Transactional
+  public void setPresentCancelReason(Present present, String cancelReason) {
+    present.setCancelReason(cancelReason);
   }
 
 }

--- a/src/main/java/com/zipup/server/present/domain/Present.java
+++ b/src/main/java/com/zipup/server/present/domain/Present.java
@@ -35,6 +35,10 @@ public class Present extends BaseTimeEntity {
   @Column
   private String congratsMessage;
 
+  @Column
+  @Setter
+  private String cancelReason;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   @Setter

--- a/src/main/java/com/zipup/server/user/application/UserService.java
+++ b/src/main/java/com/zipup/server/user/application/UserService.java
@@ -100,4 +100,9 @@ public class UserService {
     user.setStatus(ColumnStatus.UNLINK);
   }
 
+  @Transactional
+  public void setWithdrawalReason(User user, String withdrawalReason) {
+    user.setWithdrawalReason(withdrawalReason);
+  }
+
 }

--- a/src/main/java/com/zipup/server/user/facade/UserFacade.java
+++ b/src/main/java/com/zipup/server/user/facade/UserFacade.java
@@ -1,5 +1,6 @@
 package com.zipup.server.user.facade;
 
+import com.zipup.server.funding.dto.FundingCancelRequest;
 import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.util.entity.ColumnStatus;
 import com.zipup.server.user.domain.User;
@@ -12,4 +13,5 @@ public interface UserFacade<T> {
   List<T> findAllEntityByUserAndStatus(User user, ColumnStatus status);
   SimpleDataResponse unlinkUser(WithdrawalRequest userId);
   List findMyEntityList(String userId);
+  List deleteEntity(FundingCancelRequest request);
 }


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 주최자 펀딩 삭제 구현
 - fund, present 엔티티마다 삭제 이유 컬럼 구현
 - 삭제 시 엔티티 status -> private으로 전환
