### PR TITLE
[feat] #109 결제 취소 시에도 내역에 유지하도록 수정

### DIFF
--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -181,7 +181,6 @@ public class PaymentService {
       throw new BaseException(ACCESS_DENIED);
 
     if (payment.getPaymentStatus().equals(INVALID_PAYMENT_STATUS)) {
-      changePrivatePayment(payment);
       return payment.toCancelResponse(null);
     }
 
@@ -197,7 +196,6 @@ public class PaymentService {
     Mono<TossPaymentResponse> response = tossService.post("/" + request.getPaymentKey() + "/cancel", data, TossPaymentResponse.class);
     if (request.getCancelAmount() == null || request.getCancelAmount().equals(payment.getBalanceAmount())) {
       payment.setPaymentStatus(CANCELED);
-      changePrivatePayment(payment);
     } else {
       if (request.getCancelAmount() < payment.getBalanceAmount()) {
         payment.setBalanceAmount(payment.getBalanceAmount() - request.getCancelAmount());

--- a/src/main/java/com/zipup/server/payment/domain/Payment.java
+++ b/src/main/java/com/zipup/server/payment/domain/Payment.java
@@ -100,37 +100,4 @@ public class Payment extends BaseTimeEntity {
             .build();
   }
 
-  public PaymentHistoryResponse toHistoryResponse(Boolean isVirtualAccount, Boolean isDepositCompleted, Boolean refundable) {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    String historyStatus = getStatusText(paymentStatus);
-    String paymentNumber = id.toString().replaceAll("-", "");
-
-    return PaymentHistoryResponse.builder()
-            .id(id.toString())
-            .fundingName(present.getFund().getTitle())
-            .fundingImage(present.getFund().getImageUrl())
-            .paymentDate(getCreatedDate().format(formatter))
-            .status(historyStatus)
-            .amount(balanceAmount)
-            .paymentNumber(paymentNumber.substring(0, Math.min(15, paymentNumber.length())))
-            .refundable(refundable)
-            .isVirtualAccount(isVirtualAccount)
-            .isDepositCompleted(isDepositCompleted)
-            .build();
-  }
-
-  private String getStatusText(PaymentStatus status) {
-    switch (status) {
-      case DONE:
-      case READY:
-      case WAITING_FOR_DEPOSIT:
-        return "결제완료";
-      case CANCELED:
-      case PARTIAL_CANCELED:
-        return "취소완료";
-      default:
-        return "취소요청";
-    }
-  }
-
 }

--- a/src/main/java/com/zipup/server/payment/dto/PaymentHistoryResponse.java
+++ b/src/main/java/com/zipup/server/payment/dto/PaymentHistoryResponse.java
@@ -19,6 +19,8 @@ public class PaymentHistoryResponse {
   private String fundingImage;
   @Schema(description = "결제 일시", example = "yyyy-MM-dd HH:mm:ss")
   private String paymentDate;
+  @Schema(description = "특정 펀딩의 최근 결제일", example = "yyyy-MM-dd HH:mm:ss")
+  private String mostRecentPaymentDateInFunding;
   @Schema(description = "가격")
   private Integer amount;
   @Schema(description = "결제 번호")


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 결제 취소 시에도 내역에 유지하도록 수정
 - 결제 내역 조회 시 펀딩 -> 결제건 별 최신 내역 우선 순위로 정렬