### PR TITLE
[fix] #109 펀딩 상세 페이지 조회 시 private 참여 객체 안 보이도록 수정

### DIFF
--- a/src/main/java/com/zipup/server/funding/application/FundService.java
+++ b/src/main/java/com/zipup/server/funding/application/FundService.java
@@ -58,13 +58,6 @@ public class FundService {
   }
 
   @Transactional(readOnly = true)
-  public FundingDetailResponse getFundingDetail(String fundId, String userId) {
-    isValidUUID(fundId);
-
-    return findById(fundId).toDetailResponse(userId != null ? userService.findById(userId) : null);
-  }
-
-  @Transactional(readOnly = true)
   public List<FundingSummaryResponse> getFundList() {
     return fundRepository.findAll()
             .stream()

--- a/src/main/java/com/zipup/server/funding/presentation/FundController.java
+++ b/src/main/java/com/zipup/server/funding/presentation/FundController.java
@@ -106,7 +106,7 @@ public class FundController {
       isValidUUID(userId);
     }
 
-    return fundService.getFundingDetail(fundId, userId);
+    return userFacade.findEntityDetail(fundId, userId);
   }
 
   @Operation(summary = "펀딩 주최", description = "펀딩 주최")

--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -150,7 +150,8 @@ public class PaymentService {
                 log.info("Id :: {}", payment.getId());
                 log.info("Status :: {}", payment.getStatus());
                 Payment targetPayment = findByPaymentKey(payment.getPaymentKey());
-                targetPayment.setPaymentStatus(INVALID_PAYMENT_STATUS);
+                changeInvalidPaymentStatus(targetPayment);
+                log.info("Change Status :: {}", payment.getStatus());
               }
               return Mono.empty();
             }).subscribe());
@@ -239,12 +240,17 @@ public class PaymentService {
 
   @Transactional
   public void changePartialCancelPaymentStatus(Payment payment) {
-    payment.setPaymentStatus(CANCELED);
+    payment.setPaymentStatus(PARTIAL_CANCELED);
   }
 
   @Transactional
   public void changeCancelInvalidPaymentStatus(Payment payment) {
     payment.setPaymentStatus(INVALID_PAYMENT_STATUS_CANCELED);
+  }
+
+  @Transactional
+  public void changeInvalidPaymentStatus(Payment payment) {
+    payment.setPaymentStatus(INVALID_PAYMENT_STATUS);
   }
 
 }

--- a/src/main/java/com/zipup/server/present/application/PresentService.java
+++ b/src/main/java/com/zipup/server/present/application/PresentService.java
@@ -66,6 +66,11 @@ public class PresentService {
   }
 
   @Transactional(readOnly = true)
+  public List<Present> findAllByFundAndStatus(Fund fund, ColumnStatus status) {
+    return presentRepository.findAllByFundAndStatus(fund, status);
+  }
+
+  @Transactional(readOnly = true)
   public List<Present> findAllByUserAndStatusIsNot(User user, ColumnStatus status) {
     return presentRepository.findAllByUserAndStatusIsNot(user, status);
   }

--- a/src/main/java/com/zipup/server/present/infrastructure/PresentRepository.java
+++ b/src/main/java/com/zipup/server/present/infrastructure/PresentRepository.java
@@ -1,5 +1,6 @@
 package com.zipup.server.present.infrastructure;
 
+import com.zipup.server.funding.domain.Fund;
 import com.zipup.server.global.util.entity.ColumnStatus;
 import com.zipup.server.payment.domain.Payment;
 import com.zipup.server.present.domain.Present;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Repository
 public interface PresentRepository extends JpaRepository<Present, UUID> {
   List<Present> findAllByUserAndStatus(User user, ColumnStatus status);
+  List<Present> findAllByFundAndStatus(Fund fund, ColumnStatus status);
   List<Present> findAllByUserAndStatusIsNot(User user, ColumnStatus status);
   Optional<Present> findByPayment(Payment payment);
 }

--- a/src/main/java/com/zipup/server/user/facade/UserFacade.java
+++ b/src/main/java/com/zipup/server/user/facade/UserFacade.java
@@ -1,6 +1,7 @@
 package com.zipup.server.user.facade;
 
 import com.zipup.server.funding.dto.FundingCancelRequest;
+import com.zipup.server.funding.dto.FundingDetailResponse;
 import com.zipup.server.funding.dto.SimpleDataResponse;
 import com.zipup.server.global.util.entity.ColumnStatus;
 import com.zipup.server.user.domain.User;
@@ -14,4 +15,5 @@ public interface UserFacade<T> {
   SimpleDataResponse unlinkUser(WithdrawalRequest userId);
   List findMyEntityList(String userId);
   List deleteEntity(FundingCancelRequest request);
+  FundingDetailResponse findEntityDetail(String entityId, String userId);
 }


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 펀딩 상세 페이지 조회 시 private 참여 객체 안 보이도록 수정