### PR TITLE
[feat] 결제 내역 toss의 상태값 반영하도록 수정

### DIFF
--- a/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/zipup/server/global/exception/CustomErrorCode.java
@@ -35,6 +35,7 @@ public enum CustomErrorCode {
   DATABASE_ERROR(4000, "데이터베이스 연결에 실패하였습니다."),
   SERVER_ERROR(4001, "서버와의 연결에 실패하였습니다."),
   REDIS_ERROR(4002, "redis 연결에 실패하였습니다."),
+  TOSS_ERROR(4003, "toss payment 연결에 실패하였습니다."),
 
   /**
    * 5000 : 알 수 없는 오류

--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -17,7 +17,6 @@ import com.zipup.server.present.dto.ParticipateCancelRequest;
 import com.zipup.server.present.infrastructure.PresentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -210,9 +209,8 @@ public class PaymentService {
     data.put("cancelReason", request.getCancelReason());
     if (request.getCancelAmount() != null)
       data.put("cancelAmount", request.getCancelAmount());
-    if (request.getRefundReceiveAccount() != null) {
+    if (request.getRefundReceiveAccount() != null)
       data.put("refundReceiveAccount", request.getRefundReceiveAccount());
-    }
 
     Mono<TossPaymentResponse> response = tossService.post("/" + request.getPaymentKey() + "/cancel", data, TossPaymentResponse.class);
     if (request.getCancelAmount() == null || request.getCancelAmount().equals(payment.getBalanceAmount())) {
@@ -259,12 +257,10 @@ public class PaymentService {
     Map<String, Object> data = new HashMap<>();
     data.put("idempotencyKey", idempotencyKey);
     data.put("cancelReason", request.getCancelReason());
-    if (request.getCancelAmount() != null) {
+    if (request.getCancelAmount() != null)
       data.put("cancelAmount", request.getCancelAmount());
-    }
-    if (request.getRefundReceiveAccount() != null) {
+    if (request.getRefundReceiveAccount() != null)
       data.put("refundReceiveAccount", request.getRefundReceiveAccount());
-    }
     return data;
   }
 
@@ -277,11 +273,6 @@ public class PaymentService {
       payment.setBalanceAmount(payment.getBalanceAmount() - cancelAmount);
       changePartialCancelPaymentStatus(payment);
     }
-  }
-
-  @Transactional
-  public void changePrivatePayment(Payment payment) {
-    payment.setStatus(ColumnStatus.PRIVATE);
   }
 
   @Transactional

--- a/src/main/java/com/zipup/server/payment/application/PaymentService.java
+++ b/src/main/java/com/zipup/server/payment/application/PaymentService.java
@@ -17,6 +17,7 @@ import com.zipup.server.present.dto.ParticipateCancelRequest;
 import com.zipup.server.present.infrastructure.PresentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -168,6 +169,7 @@ public class PaymentService {
               if (tossPaymentResponse != null) {
                 Payment payment = findByPaymentKey(tossPaymentResponse.getPaymentKey());
                 payment.setPaymentStatus(tossPaymentResponse.getStatus());
+                paymentRepository.save(payment);
               }
               return Mono.justOrEmpty(tossPaymentResponse);
             });
@@ -180,6 +182,7 @@ public class PaymentService {
               if (tossPaymentResponse != null) {
                 Payment payment = findByPaymentKey(tossPaymentResponse.getPaymentKey());
                 payment.setPaymentStatus(tossPaymentResponse.getStatus());
+                paymentRepository.save(payment);
               }
               return Mono.justOrEmpty(tossPaymentResponse);
             });


### PR DESCRIPTION
## 💡 구현할 기능 설명
 - 결제 내역 업데이트 시 transaction 고려해 save 직접 기입
 - 결제 내역 조회 시 toss 상태값으로 응답